### PR TITLE
feat: community host installer improvements — hooks, persistence, MissionScripting patch

### DIFF
--- a/agent/controller.py
+++ b/agent/controller.py
@@ -300,8 +300,9 @@ _HOOK_STALE_SECONDS = 300  # hook writes every 5 s; discard if silent for 5 min
 def _read_hook_status(log_path: str) -> dict:
     """Read the dcs_agent_status.json written by the Lua hook, or return {}.
 
-    Returns {} if the file is missing, unreadable, or stale (updated_at older
-    than _HOOK_STALE_SECONDS), so callers never see stale mission/player data.
+    Returns {} if the file is missing or unreadable.  If stale, returns the
+    last known mission data with player fields zeroed so callers show the last
+    known mission time rather than --- while still showing 0 players.
     """
     status_file = Path(log_path).parent / "dcs_agent_status.json"
     if not status_file.exists():
@@ -315,7 +316,9 @@ def _read_hook_status(log_path: str) -> dict:
         try:
             updated_at = datetime.fromisoformat(updated_at_str.replace("Z", "+00:00"))
             if (datetime.now(timezone.utc) - updated_at).total_seconds() > _HOOK_STALE_SECONDS:
-                return {}
+                data["player_count"] = 0
+                data["players"] = []
+                return data
         except (ValueError, TypeError):
             pass
     return data

--- a/agent/controller.py
+++ b/agent/controller.py
@@ -197,14 +197,18 @@ def _dedup_blocks(blocks: list[list[str]]) -> list[str]:
 # ------------------------------------------------------------------
 
 def _kill_any_dcs_server() -> None:
-    """Kill all DCS_server.exe processes regardless of how they were started.
+    """Kill DCS_server.exe processes that were NOT started with a -w flag.
 
     Prevents port conflicts when a user has DCS running via a desktop shortcut
     (without -w flag) at the same time the agent tries to start it via Task Scheduler.
+    Managed instances always include -w <saved_games_key> in their command line,
+    so this only removes unmanaged orphans.
     """
     subprocess.run(
         ["powershell", "-NoProfile", "-Command",
-         "Get-Process DCS_server -ErrorAction SilentlyContinue | Stop-Process -Force"],
+         "Get-CimInstance Win32_Process -Filter \"name='DCS_server.exe'\" "
+         "| Where-Object { $_.CommandLine -notlike '*-w *' } "
+         "| ForEach-Object { Stop-Process -Id $_.ProcessId -Force }"],
         capture_output=True, text=True,
     )
 

--- a/scripts/install-agent.ps1
+++ b/scripts/install-agent.ps1
@@ -185,7 +185,7 @@ if ($Update) {
                 $patched = $true
             }
             if ($patched) {
-                [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.Encoding]::UTF8)
+                [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.UTF8Encoding]::new($false))
                 Write-Ok "MissionScripting.lua patched — io/lfs unsanitized"
             } else {
                 Write-Ok "MissionScripting.lua already patched — no changes needed"
@@ -686,7 +686,7 @@ if (Test-Path $missionScriptingPath) {
         $patched = $true
     }
     if ($patched) {
-        [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.Encoding]::UTF8)
+        [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.UTF8Encoding]::new($false))
         Write-Ok "MissionScripting.lua patched — io/lfs unsanitized"
     } else {
         Write-Ok "MissionScripting.lua already patched — no changes needed"

--- a/scripts/install-agent.ps1
+++ b/scripts/install-agent.ps1
@@ -149,6 +149,50 @@ if ($Update) {
         Write-Ok "update_DCS_auto.ps1 updated"
     }
 
+    # Update DCS Lua status hook
+    $hookSrc = "$InstallDir\src\agent\scripts\dcs_agent_hook.lua"
+    if (Test-Path $hookSrc) {
+        $savedGamesBase = [System.IO.Path]::Combine($env:USERPROFILE, "Saved Games")
+        $dcsProfiles = @(Get-ChildItem -Path $savedGamesBase -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like "DCS*" })
+        foreach ($profile in $dcsProfiles) {
+            $hooksDir = "$($profile.FullName)\Scripts\Hooks"
+            New-Item -ItemType Directory -Force -Path $hooksDir | Out-Null
+            Copy-Item $hookSrc "$hooksDir\dcs_agent_hook.lua" -Force
+            Write-Ok "Hook updated: $hooksDir"
+        }
+    } else {
+        Write-Warn "Hook script not found at $hookSrc — skipping"
+    }
+
+    # Patch MissionScripting.lua for persistence (io/lfs)
+    $dcsExePaths = @(
+        "C:\Program Files\Eagle Dynamics\DCS World OpenBeta Server\bin\DCS_server.exe",
+        "C:\Program Files\Eagle Dynamics\DCS World Server\bin\DCS_server.exe"
+    )
+    $foundDcsExe = $dcsExePaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+    if ($foundDcsExe) {
+        $missionScriptingPath = "$(Split-Path (Split-Path $foundDcsExe -Parent) -Parent)\Scripts\MissionScripting.lua"
+        if (Test-Path $missionScriptingPath) {
+            $ms = [System.IO.File]::ReadAllText($missionScriptingPath)
+            $patched = $false
+            if ($ms -match "(?m)^\s*sanitizeModule\('io'\)") {
+                $ms = $ms -replace "(?m)^(\s*)(sanitizeModule\('io'\))", '$1--$2  -- DCS Platform: unsanitized for persistence'
+                $patched = $true
+            }
+            if ($ms -match "(?m)^\s*sanitizeModule\('lfs'\)") {
+                $ms = $ms -replace "(?m)^(\s*)(sanitizeModule\('lfs'\))", '$1--$2  -- DCS Platform: unsanitized for persistence'
+                $patched = $true
+            }
+            if ($patched) {
+                [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.Encoding]::UTF8)
+                Write-Ok "MissionScripting.lua patched — io/lfs unsanitized"
+            } else {
+                Write-Ok "MissionScripting.lua already patched — no changes needed"
+            }
+        }
+    }
+
     Write-Step "Starting DCSAgent service"
     Start-Service DCSAgent
     Write-Ok "DCSAgent restarted with updated source"

--- a/scripts/install-agent.ps1
+++ b/scripts/install-agent.ps1
@@ -625,7 +625,34 @@ if (Test-Path $hookSrc) {
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 17. Start services
+# 17. Unsanitize io/lfs in MissionScripting.lua (required for persistence)
+# ══════════════════════════════════════════════════════════════════════════════
+Write-Step "Patching MissionScripting.lua for persistence (io/lfs)"
+
+$missionScriptingPath = "$(Split-Path $dcsBinDir -Parent)\Scripts\MissionScripting.lua"
+if (Test-Path $missionScriptingPath) {
+    $ms = [System.IO.File]::ReadAllText($missionScriptingPath)
+    $patched = $false
+    if ($ms -match "(?m)^\s*sanitizeModule\('io'\)") {
+        $ms = $ms -replace "(?m)^(\s*)(sanitizeModule\('io'\))", '$1--$2  -- DCS Platform: unsanitized for persistence'
+        $patched = $true
+    }
+    if ($ms -match "(?m)^\s*sanitizeModule\('lfs'\)") {
+        $ms = $ms -replace "(?m)^(\s*)(sanitizeModule\('lfs'\))", '$1--$2  -- DCS Platform: unsanitized for persistence'
+        $patched = $true
+    }
+    if ($patched) {
+        [System.IO.File]::WriteAllText($missionScriptingPath, $ms, [System.Text.Encoding]::UTF8)
+        Write-Ok "MissionScripting.lua patched — io/lfs unsanitized"
+    } else {
+        Write-Ok "MissionScripting.lua already patched — no changes needed"
+    }
+} else {
+    Write-Warn "MissionScripting.lua not found at $missionScriptingPath — skipping. Persistence scripts will not work."
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# 18. Start services
 # ══════════════════════════════════════════════════════════════════════════════
 Write-Step "Starting services"
 


### PR DESCRIPTION
## Summary
  - Add keepalive cooldown (20 min) to prevent rapid restart spam; suppress duplicate `stopped→starting` notifications
  - Installer: patch `MissionScripting.lua` to unsanitize `io`/`lfs` for Lua persistence scripts (no BOM)
  - Installer: copy `dcs_agent_hook.lua` to DCS `Scripts/Hooks` on fresh install
  - Fix `-Update` mode to also re-copy hook to all DCS profiles and re-apply `MissionScripting.lua` patch

  ## Test plan
  - [x] Fresh install copies hook to `Scripts/Hooks` and patches `MissionScripting.lua`
  - [x] Update command re-copies hook to all DCS profiles
  - [x] No BOM written to `MissionScripting.lua` (Lua loads without `unexpected symbol near 'ï'` error)
  - [x] `MissionScripting.lua` patch is idempotent — re-running install/update skips if already patched
  - [x] Auto-restart notifications fire at ~20 min cooldown instead of every 5 min
  - [ ] Verify player count and mission time populate in `/dcs status` after server restart