### PR TITLE
feat: /dcs update — automated DCS update with live Discord progress

### DIFF
--- a/agent/controller.py
+++ b/agent/controller.py
@@ -775,26 +775,134 @@ class DcsController:
     _UPDATE_STATUS_FILE = Path(r"C:\ProgramData\DCSAgent\update_status.json")
 
     def trigger_dcs_update(self) -> dict:
-        """Trigger the DCS-UpdateDCS Task Scheduler task (runs update_DCS_auto.ps1 as SYSTEM)."""
-        # Clear any stale status before starting
+        """Start the DCS update process in a background thread.
+
+        Returns immediately. Poll get_update_status() for progress.
+        The agent process already runs as the correct Windows user so
+        DCS_updater.exe can authenticate without a Task Scheduler task.
+        """
+        import threading
         if self._UPDATE_STATUS_FILE.exists():
             try:
                 self._UPDATE_STATUS_FILE.unlink()
             except OSError:
                 pass
-        result = subprocess.run(
-            ["schtasks", "/run", "/tn", "DCS-UpdateDCS"],
-            capture_output=True, text=True,
-        )
-        if result.returncode != 0:
-            raise RuntimeError(f"schtasks /run failed: {(result.stdout + result.stderr).strip()}")
+        thread = threading.Thread(target=self._run_update, daemon=True)
+        thread.start()
         return {"triggered": True}
+
+    def _write_update_status(self, phase: str, running: bool, message: str) -> None:
+        self._UPDATE_STATUS_FILE.parent.mkdir(parents=True, exist_ok=True)
+        data = {
+            "phase": phase,
+            "running": running,
+            "message": message,
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        self._UPDATE_STATUS_FILE.write_text(json.dumps(data, indent=4), encoding="utf-8")
+
+    def _run_update(self) -> None:
+        """Background thread: stop instances → update DCS → restart instances."""
+        import time
+        import re
+        import urllib.request
+
+        try:
+            self._write_update_status("starting", True, "Reading agent config...")
+
+            instances = self._config.instances
+            if not instances:
+                self._write_update_status("failed", False, "No instances found in config")
+                return
+
+            updater_path = Path(instances[0].exe_path).parent / "DCS_updater.exe"
+            if not updater_path.exists():
+                self._write_update_status("failed", False, f"DCS_updater.exe not found at: {updater_path}")
+                return
+
+            # Read current version before updating
+            dcs_root = updater_path.parent.parent
+            cfg_path = dcs_root / "autoupdate.cfg"
+            version_before = "unknown"
+            if cfg_path.exists():
+                try:
+                    version_before = json.loads(cfg_path.read_text(encoding="utf-8")).get("version", "unknown")
+                except Exception:
+                    pass
+
+            # Stop all instances
+            self._write_update_status("stopping", True, "Stopping all DCS servers...")
+            for inst in instances:
+                subprocess.run(["schtasks", "/end", "/tn", inst.service_name], capture_output=True)
+                ps = (
+                    f"$p = Get-CimInstance Win32_Process -Filter \"name='DCS_server.exe'\" "
+                    f"| Where-Object {{ $_.CommandLine -like '*{inst.saved_games_key}*' }}; "
+                    f"if ($p) {{ Stop-Process -Id $p.ProcessId -Force }}"
+                )
+                subprocess.run(["powershell", "-NoProfile", "-Command", ps], capture_output=True)
+            time.sleep(10)
+
+            # Fetch latest version from DCS changelog
+            target_version: str | None = None
+            try:
+                with urllib.request.urlopen(
+                    "https://www.digitalcombatsimulator.com/en/news/changelog/release/",
+                    timeout=10,
+                ) as resp:
+                    content = resp.read().decode("utf-8", errors="ignore")
+                m = re.search(r"/en/news/changelog/release/(\d+\.\d+\.\d+\.\d+)/", content)
+                if m:
+                    target_version = m.group(1)
+            except Exception:
+                pass
+
+            msg = (
+                f"Running DCS updater — updating to {target_version}..."
+                if target_version
+                else "Running DCS updater — this may take 10-60 minutes..."
+            )
+            self._write_update_status("updating", True, msg)
+
+            # Run DCS_updater.exe directly (inherits agent user credentials)
+            cmd = (
+                [str(updater_path), "update", target_version]
+                if target_version
+                else [str(updater_path), "--quiet", "update"]
+            )
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd=str(updater_path.parent))
+            if result.returncode != 0:
+                self._write_update_status("failed", False, f"DCS_updater.exe failed with exit code {result.returncode}")
+                return
+
+            # Restart all instances
+            self._write_update_status("restarting", True, "Restarting DCS servers...")
+            for inst in instances:
+                subprocess.run(["schtasks", "/run", "/tn", inst.service_name], capture_output=True)
+                time.sleep(5)
+
+            # Read version after and report
+            version_after = "unknown"
+            if cfg_path.exists():
+                try:
+                    version_after = json.loads(cfg_path.read_text(encoding="utf-8")).get("version", "unknown")
+                except Exception:
+                    pass
+
+            if version_after != version_before and version_after != "unknown":
+                complete_msg = f"Updated {version_before} \u2192 {version_after}. Servers are coming back online."
+            else:
+                complete_msg = f"Already up to date ({version_after}). Servers are coming back online."
+            self._write_update_status("complete", False, complete_msg)
+
+        except Exception as exc:
+            self._write_update_status("failed", False, f"Unexpected error: {exc}")
 
     def get_update_status(self) -> dict:
         """Read the current DCS update status from the status JSON written by the update script."""
         if not self._UPDATE_STATUS_FILE.exists():
             return {"phase": "idle", "running": False, "message": "No update in progress"}
         try:
-            return json.loads(self._UPDATE_STATUS_FILE.read_text(encoding="utf-8"))
+            # utf-8-sig strips BOM if present (e.g. written by PowerShell Set-Content)
+            return json.loads(self._UPDATE_STATUS_FILE.read_text(encoding="utf-8-sig"))
         except (OSError, json.JSONDecodeError):
             return {"phase": "unknown", "running": False, "message": "Could not read status"}

--- a/agent/scripts/update_DCS_auto.ps1
+++ b/agent/scripts/update_DCS_auto.ps1
@@ -54,6 +54,14 @@ try {
         exit 1
     }
 
+    # Read current DCS version before updating
+    $dcsRoot    = Split-Path (Split-Path $updaterPath -Parent) -Parent
+    $cfgPath    = "$dcsRoot\autoupdate.cfg"
+    $versionBefore = "unknown"
+    if (Test-Path $cfgPath) {
+        try { $versionBefore = (Get-Content $cfgPath -Raw | ConvertFrom-Json).version } catch { }
+    }
+
     # ── Stop all DCS instances ────────────────────────────────────────────────
     Write-Status "stopping" $true "Stopping all DCS servers..."
 
@@ -73,15 +81,34 @@ try {
     # Give processes time to fully exit
     Start-Sleep -Seconds 10
 
+    # ── Fetch latest version from DCS changelog ───────────────────────────────
+    $targetVersion = $null
+    try {
+        $page  = Invoke-WebRequest -Uri "https://www.digitalcombatsimulator.com/en/news/changelog/release/" -UseBasicParsing
+        $match = [regex]::Match($page.Content, '/en/news/changelog/release/(\d+\.\d+\.\d+\.\d+)/')
+        if ($match.Success) { $targetVersion = $match.Groups[1].Value }
+    } catch { }
+
     # ── Run DCS_updater.exe ───────────────────────────────────────────────────
-    Write-Status "updating" $true "Running DCS updater — this may take 10-60 minutes..."
+    $updateMsg = if ($targetVersion) { "Running DCS updater — updating to $targetVersion..." } `
+                 else                { "Running DCS updater — this may take 10-60 minutes..." }
+    Write-Status "updating" $true $updateMsg
 
-    $updater = Start-Process -FilePath $updaterPath `
-                             -ArgumentList "update" `
-                             -Wait -PassThru -NoNewWindow
+    $updaterDir = Split-Path $updaterPath -Parent
+    Push-Location $updaterDir
+    try {
+        if ($targetVersion) {
+            & $updaterPath "update" $targetVersion
+        } else {
+            & $updaterPath "--quiet" "update"
+        }
+        $updaterExit = $LASTEXITCODE
+    } finally {
+        Pop-Location
+    }
 
-    if ($updater.ExitCode -ne 0) {
-        Write-Status "failed" $false "DCS_updater.exe failed with exit code $($updater.ExitCode)"
+    if ($updaterExit -ne 0) {
+        Write-Status "failed" $false "DCS_updater.exe failed with exit code $updaterExit"
         exit 1
     }
 
@@ -93,7 +120,18 @@ try {
         Start-Sleep -Seconds 5
     }
 
-    Write-Status "complete" $false "Update complete. Servers are coming back online."
+    # Read version after update and report what changed
+    $versionAfter = "unknown"
+    if (Test-Path $cfgPath) {
+        try { $versionAfter = (Get-Content $cfgPath -Raw | ConvertFrom-Json).version } catch { }
+    }
+
+    $completeMsg = if ($versionAfter -ne $versionBefore) {
+        "Updated $versionBefore -> $versionAfter. Servers are coming back online."
+    } else {
+        "Already up to date ($versionAfter). Servers are coming back online."
+    }
+    Write-Status "complete" $false $completeMsg
 
 } catch {
     Write-Status "failed" $false "Unexpected error: $_"

--- a/discord-bot/cogs/dcs.py
+++ b/discord-bot/cogs/dcs.py
@@ -286,6 +286,35 @@ class _ConfirmView(discord.ui.View):
 
 _KEEPALIVE_COOLDOWN = 20 * 60  # seconds between restart attempts per instance
 
+_UPDATE_PHASE_COLOURS: dict[str, int] = {
+    "starting":   0xE67E22,
+    "stopping":   0xE67E22,
+    "updating":   0x3498DB,
+    "restarting": 0xE67E22,
+    "complete":   0x2ECC71,
+    "failed":     0xE74C3C,
+}
+_UPDATE_PHASE_ICONS: dict[str, str] = {
+    "starting":   "🔄",
+    "stopping":   "🛑",
+    "updating":   "⬇️",
+    "restarting": "🔁",
+    "complete":   "✅",
+    "failed":     "❌",
+}
+
+
+def _update_phase_embed(host: str, phase: str, message: str) -> discord.Embed:
+    colour = _UPDATE_PHASE_COLOURS.get(phase, 0x95A5A6)
+    icon   = _UPDATE_PHASE_ICONS.get(phase, "🔄")
+    embed  = discord.Embed(
+        title=f"{icon} DCS Update — `{host}`",
+        description=message,
+        colour=colour,
+    )
+    embed.set_footer(text=f"Phase: {phase}")
+    return embed
+
 
 class DcsCog(commands.Cog):
     def __init__(self, config: BotConfig, client: OrchestratorClient, bot: commands.Bot) -> None:
@@ -1662,16 +1691,46 @@ class DcsCog(commands.Cog):
                 )
                 return
 
-            # Announce publicly in status channel
+            # Post a live-updating embed in the status channel
             status_ch = self._status_channel()
+            status_msg: discord.Message | None = None
             if status_ch:
-                await status_ch.send(
-                    f"🔄 DCS update started on `{host}` — its servers are stopping now. "
-                    "They will restart automatically when the update finishes (~10–60 min)."
+                status_msg = await status_ch.send(
+                    embed=_update_phase_embed(host, "starting", "Starting update...")
                 )
             await interaction.edit_original_response(
-                content="✅ Update triggered. Watch the status channel for progress.", view=None
+                content="Update triggered. Watch the status channel for progress.", view=None
             )
+
+            # Background task: poll status and edit the embed until done
+            async def _poll_update() -> None:
+                _PHASE_LABELS = {
+                    "starting":   "Starting...",
+                    "stopping":   "Stopping servers...",
+                    "updating":   "Downloading update...",
+                    "restarting": "Restarting servers...",
+                    "complete":   "Complete",
+                    "failed":     "Failed",
+                }
+                _POLL_INTERVAL = 10   # seconds between polls
+                _MAX_POLLS     = 360  # 60 minutes max
+                for _ in range(_MAX_POLLS):
+                    await asyncio.sleep(_POLL_INTERVAL)
+                    try:
+                        st = await client.get_update_status(matched["id"])
+                    except Exception:
+                        continue
+                    if status_msg:
+                        try:
+                            await status_msg.edit(
+                                embed=_update_phase_embed(host, st.get("phase", ""), st.get("message", ""))
+                            )
+                        except Exception:
+                            pass
+                    if not st.get("running", True):
+                        break
+
+            asyncio.create_task(_poll_update())
 
         # ---------------------------------------------------------------- #
         # /dcs copy-mission                                                  #

--- a/scripts/install-agent.ps1
+++ b/scripts/install-agent.ps1
@@ -193,6 +193,46 @@ if ($Update) {
         }
     }
 
+    # Recreate DCS-UpdateDCS task so it runs as current user (not SYSTEM)
+    $updateScript  = "$InstallDir\update_DCS_auto.ps1"
+    $updateCfgPath = "$InstallDir\config.json"
+    $updateSid     = [System.Security.Principal.WindowsIdentity]::GetCurrent().User.Value
+    $updateTaskXml = @"
+<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.3" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <URI>\DCS-UpdateDCS</URI>
+    <Description>Stops DCS servers, runs DCS_updater.exe, restarts servers. Triggered by DCS Agent.</Description>
+  </RegistrationInfo>
+  <Principals>
+    <Principal id="Author">
+      <UserId>$updateSid</UserId>
+      <LogonType>InteractiveToken</LogonType>
+    </Principal>
+  </Principals>
+  <Settings>
+    <DisallowStartIfOnBatteries>false</DisallowStartIfOnBatteries>
+    <StopIfGoingOnBatteries>false</StopIfGoingOnBatteries>
+    <ExecutionTimeLimit>PT2H</ExecutionTimeLimit>
+    <MultipleInstancesPolicy>IgnoreNew</MultipleInstancesPolicy>
+    <UseUnifiedSchedulingEngine>true</UseUnifiedSchedulingEngine>
+  </Settings>
+  <Triggers />
+  <Actions Context="Author">
+    <Exec>
+      <Command>powershell.exe</Command>
+      <Arguments>-NoProfile -ExecutionPolicy Bypass -File "$updateScript" -ConfigFile "$updateCfgPath"</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+"@
+    $tmpUpdateXml = [System.IO.Path]::GetTempFileName() + ".xml"
+    [System.IO.File]::WriteAllText($tmpUpdateXml, $updateTaskXml, [System.Text.Encoding]::Unicode)
+    try { schtasks /delete /tn "DCS-UpdateDCS" /f 2>&1 | Out-Null } catch { }
+    schtasks /create /tn "DCS-UpdateDCS" /xml $tmpUpdateXml /f | Out-Null
+    Remove-Item $tmpUpdateXml -ErrorAction SilentlyContinue
+    Write-Ok "DCS-UpdateDCS task recreated (runs as current user)"
+
     Write-Step "Starting DCSAgent service"
     Start-Service DCSAgent
     Write-Ok "DCSAgent restarted with updated source"
@@ -598,7 +638,7 @@ Remove-Item $tmpXml -ErrorAction SilentlyContinue
 Write-Ok "Task Scheduler task created: $ServiceName"
 
 # ══════════════════════════════════════════════════════════════════════════════
-# 15. Create DCS-UpdateDCS Task Scheduler task (runs as SYSTEM)
+# 15. Create DCS-UpdateDCS Task Scheduler task (runs as current user — DCS_updater.exe needs user credentials)
 # ══════════════════════════════════════════════════════════════════════════════
 Write-Step "Creating DCS-UpdateDCS update task"
 
@@ -620,8 +660,8 @@ $updateTaskXml = @"
   </RegistrationInfo>
   <Principals>
     <Principal id="Author">
-      <UserId>S-1-5-18</UserId>
-      <RunLevel>HighestAvailable</RunLevel>
+      <UserId>$sid</UserId>
+      <LogonType>InteractiveToken</LogonType>
     </Principal>
   </Principals>
   <Settings>
@@ -646,7 +686,7 @@ $tmpUpdateXml = [System.IO.Path]::GetTempFileName() + ".xml"
 try { schtasks /delete /tn "DCS-UpdateDCS" /f 2>&1 | Out-Null } catch { }
 schtasks /create /tn "DCS-UpdateDCS" /xml $tmpUpdateXml /f | Out-Null
 Remove-Item $tmpUpdateXml -ErrorAction SilentlyContinue
-Write-Ok "DCS-UpdateDCS task created (runs as SYSTEM)"
+Write-Ok "DCS-UpdateDCS task created (runs as current user)"
 
 # Ensure ProgramData status directory exists and is writable by SYSTEM
 New-Item -ItemType Directory -Force -Path "C:\ProgramData\DCSAgent" | Out-Null


### PR DESCRIPTION
## Summary

- Run DCS update directly in the agent process (background thread) so `DCS_updater.exe` inherits the correct user credentials — no Task Scheduler session required
- Fetch latest version from the DCS changelog page and pass it as the version argument to bypass the Update/Later GUI dialog
- Report version before/after in status: `Updated 2.9.24.20232 → 2.9.25.21123` or `Already up to date (x.x.x.xxxxx)`
- Live-updating Discord embed that polls status every 10 seconds and edits in place as phases change (`stopping → updating → restarting → complete/failed`)
- Installer `-Update` mode now also recreates the `DCS-UpdateDCS` task as the current user
- Fix `utf-8-sig` reading of status file to handle PowerShell BOM

## Test plan

- [x] `/dcs update` triggers update on test server
- [x] Discord embed appears and updates live through each phase
- [x] Status message shows correct version diff on completion
- [x] `Already up to date` shown when no update available
- [x] BOM-written status file parsed correctly