### PR TITLE
ci: add GitHub Actions workflow for orchestrator and agent tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [Master, Testing]
+
+jobs:
+  test-orchestrator:
+    name: Orchestrator Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r orchestrator/requirements.txt httpx pytest pytest-asyncio
+
+      - name: Run tests
+        run: pytest orchestrator/tests/ -v
+
+  test-agent:
+    name: Agent Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install -r agent/requirements.txt httpx pytest pytest-asyncio
+
+      - name: Run tests
+        run: pytest agent/tests/ -v


### PR DESCRIPTION
Runs pytest for both packages on ubuntu-latest on every push to Master/Testing and on all pull requests.