### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/TylerDOC1776/dcs-bullseye/security/code-scanning/9](https://github.com/TylerDOC1776/dcs-bullseye/security/code-scanning/9)

In general, the fix is to explicitly define a minimal `permissions:` block for the workflow or individual jobs so that the `GITHUB_TOKEN` has only the scopes actually required. For this CI workflow, all jobs only need to read the repository contents (for `actions/checkout`) and do not need to write anything back to GitHub, create releases, manage issues, etc. Therefore we can safely set `permissions: contents: read` at the workflow root level so it applies to all jobs.

The best fix with minimal change is to add a `permissions:` block immediately under the top-level `name: CI` (and before `on:`) in `.github/workflows/ci.yml`. This will apply to the whole workflow since none of the jobs currently define their own permissions. No additional imports or methods are needed since this is YAML configuration only. Functionality remains unchanged because the jobs already only require read access to repository contents, which they will still have via `contents: read`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
