### PR TITLE
fix: degraded status for stuck/login servers, cap keepalive retries

### DIFF
--- a/agent/api/models.py
+++ b/agent/api/models.py
@@ -16,6 +16,7 @@ class InstanceStatus(str, Enum):
     stopped = "stopped"
     starting = "starting"
     stopping = "stopping"
+    degraded = "degraded"
     error = "error"
     unknown = "unknown"
 
@@ -26,6 +27,7 @@ _NSSM_STATUS_MAP: dict[str, InstanceStatus] = {
     "SERVICE_START_PENDING": InstanceStatus.starting,
     "SERVICE_STOP_PENDING": InstanceStatus.stopping,
     "SERVICE_PAUSED": InstanceStatus.stopped,
+    "SERVICE_DEGRADED": InstanceStatus.degraded,
 }
 
 

--- a/agent/controller.py
+++ b/agent/controller.py
@@ -343,6 +343,7 @@ def _read_hook_status(log_path: str) -> dict:
             ).total_seconds() > _HOOK_STALE_SECONDS:
                 data["player_count"] = 0
                 data["players"] = []
+                data["_stale"] = True
                 return data
         except (ValueError, TypeError):
             pass
@@ -521,6 +522,8 @@ class DcsController:
                 _get_mission_info_from_log(instance.log_path)
             )
             hook = _read_hook_status(instance.log_path)
+            if hook.get("_stale"):
+                status_raw = "SERVICE_DEGRADED"
 
         return {
             "status": status_raw,

--- a/agent/scripts/dcs_agent_hook.lua
+++ b/agent/scripts/dcs_agent_hook.lua
@@ -9,7 +9,7 @@
 
 local UPDATE_INTERVAL = 5 -- seconds between periodic refreshes
 
-local _last_update = -UPDATE_INTERVAL
+local _last_update = 0
 local _mission_loaded = false
 
 -- Player cache: id -> name  (maintained via callbacks, bypasses net.getAllPlayers)
@@ -168,13 +168,13 @@ function agentHook.onSimulationFrame()
 	if not _mission_loaded then
 		return
 	end
-	local ok, t = pcall(DCS.getModelTime)
-	if not ok then
-		return
-	end
-	if t - _last_update >= UPDATE_INTERVAL then
-		_last_update = t
-		_status.mission_time_seconds = math.floor(t)
+	local now = os.time()
+	if now - _last_update >= UPDATE_INTERVAL then
+		_last_update = now
+		local ok, t = pcall(DCS.getModelTime)
+		if ok then
+			_status.mission_time_seconds = math.floor(t)
+		end
 		write_status()
 	end
 end

--- a/discord-bot/cogs/dcs.py
+++ b/discord-bot/cogs/dcs.py
@@ -35,6 +35,7 @@ _STATUS_COLOURS: dict[str, int] = {
     "error": 0xE74C3C,
     "starting": 0xE67E22,
     "stopping": 0xE67E22,
+    "degraded": 0xE67E22,
 }
 _COLOUR_UNKNOWN = 0x95A5A6
 
@@ -166,7 +167,7 @@ def _instances_summary_embed(instances: list[dict]) -> discord.Embed:
             else "🔴"
             if status in ("stopped", "error")
             else "🟡"
-            if status in ("starting", "stopping")
+            if status in ("starting", "stopping", "degraded")
             else "⚫"
         )
         lines = [f"{dot} {status.title()}"]
@@ -291,6 +292,7 @@ class _ConfirmView(discord.ui.View):
 # ------------------------------------------------------------------ #
 
 _KEEPALIVE_COOLDOWN = 20 * 60  # seconds between restart attempts per instance
+_KEEPALIVE_MAX_ATTEMPTS = 3
 
 _UPDATE_PHASE_COLOURS: dict[str, int] = {
     "starting": 0xE67E22,
@@ -332,6 +334,9 @@ class DcsCog(commands.Cog):
         self._status_message_id: int | None = None
         # keepalive cooldown: instance_id → monotonic time of last start attempt
         self._keepalive_last_attempt: dict[str, float] = {}
+        # keepalive attempt counter and exhausted set
+        self._keepalive_attempts: dict[str, int] = {}
+        self._keepalive_exhausted: set[str] = set()
         self.dcs: app_commands.Group = app_commands.Group(
             name="dcs", description="Manage DCS World server instances"
         )
@@ -495,8 +500,10 @@ class DcsCog(commands.Cog):
                     await channel.send(f"❌ Auto-restart failed for **{name}**: {exc}")
 
     def keepalive_clear(self, instance_id: str) -> None:
-        """Clear the keepalive cooldown for an instance (call when it reaches 'running')."""
+        """Clear the keepalive state for an instance (call when it reaches 'running')."""
         self._keepalive_last_attempt.pop(instance_id, None)
+        self._keepalive_attempts.pop(instance_id, None)
+        self._keepalive_exhausted.discard(instance_id)
 
     async def _run_keepalive_check(self) -> None:
         """Start any non-excluded instance that is stopped."""
@@ -518,6 +525,9 @@ class DcsCog(commands.Cog):
             if runtime.get("status") != "stopped":
                 continue
 
+            if instance_id in self._keepalive_exhausted:
+                continue
+
             last = self._keepalive_last_attempt.get(instance_id)
             if last is not None and now - last < _KEEPALIVE_COOLDOWN:
                 remaining = int(_KEEPALIVE_COOLDOWN - (now - last))
@@ -528,11 +538,24 @@ class DcsCog(commands.Cog):
                 )
                 continue
 
+            attempt = self._keepalive_attempts.get(instance_id, 0) + 1
+            self._keepalive_attempts[instance_id] = attempt
             self._keepalive_last_attempt[instance_id] = now
-            log.info("Keepalive: starting stopped instance %s", name)
+
+            if attempt > _KEEPALIVE_MAX_ATTEMPTS:
+                self._keepalive_exhausted.add(instance_id)
+                log.warning("Keepalive: giving up on %s after %d attempts", name, _KEEPALIVE_MAX_ATTEMPTS)
+                if channel:
+                    await channel.send(
+                        f"⛔ Auto-start failed for **{name}** after {_KEEPALIVE_MAX_ATTEMPTS} attempts — "
+                        f"manual intervention required."
+                    )
+                continue
+
+            log.info("Keepalive: starting stopped instance %s (attempt %d/%d)", name, attempt, _KEEPALIVE_MAX_ATTEMPTS)
             if channel:
                 await channel.send(
-                    f"🔁 Auto-starting **{name}** — instance was stopped."
+                    f"🔁 Auto-starting **{name}** — instance was stopped (attempt {attempt}/{_KEEPALIVE_MAX_ATTEMPTS})."
                 )
             try:
                 await self.client.trigger_action(

--- a/discord-bot/cogs/dcs.py
+++ b/discord-bot/cogs/dcs.py
@@ -544,7 +544,11 @@ class DcsCog(commands.Cog):
 
             if attempt > _KEEPALIVE_MAX_ATTEMPTS:
                 self._keepalive_exhausted.add(instance_id)
-                log.warning("Keepalive: giving up on %s after %d attempts", name, _KEEPALIVE_MAX_ATTEMPTS)
+                log.warning(
+                    "Keepalive: giving up on %s after %d attempts",
+                    name,
+                    _KEEPALIVE_MAX_ATTEMPTS,
+                )
                 if channel:
                     await channel.send(
                         f"⛔ Auto-start failed for **{name}** after {_KEEPALIVE_MAX_ATTEMPTS} attempts — "
@@ -552,7 +556,12 @@ class DcsCog(commands.Cog):
                     )
                 continue
 
-            log.info("Keepalive: starting stopped instance %s (attempt %d/%d)", name, attempt, _KEEPALIVE_MAX_ATTEMPTS)
+            log.info(
+                "Keepalive: starting stopped instance %s (attempt %d/%d)",
+                name,
+                attempt,
+                _KEEPALIVE_MAX_ATTEMPTS,
+            )
             if channel:
                 await channel.send(
                     f"🔁 Auto-starting **{name}** — instance was stopped (attempt {attempt}/{_KEEPALIVE_MAX_ATTEMPTS})."


### PR DESCRIPTION
## Summary

- Agent reports `degraded` instead of `running` when the Lua hook goes stale (DCS stuck at login screen or otherwise unresponsive)
- Hook now uses wall clock time for write interval so paused missions don't false-positive as degraded
- Bot shows yellow dot for `degraded` status
- Keepalive auto-start capped at 3 attempts with a manual intervention alert

## Test plan

- [x] Server paused 12+ minutes — stays green
- [x] Server stuck at DCS login screen — shows degraded (yellow)
- [x] Closes #18