### PR TITLE
bench: queue API, scheduler, and orchestrator config

### DIFF
--- a/orchestrator/agent_client.py
+++ b/orchestrator/agent_client.py
@@ -280,6 +280,14 @@ class AgentClient:
         """DELETE /agent/v1/instances/{serviceId}/schedule."""
         await self._delete(f"/instances/{service_name}/schedule")
 
+    async def bench_monitor_start(self, service_name: str) -> dict[str, Any]:
+        """POST /agent/v1/bench/monitor/start — start bench_monitor.py for an instance."""
+        return await self._post("/bench/monitor/start", body={"service_name": service_name})
+
+    async def bench_monitor_stop(self) -> dict[str, Any]:
+        """POST /agent/v1/bench/monitor/stop — stop the running bench monitor."""
+        return await self._post("/bench/monitor/stop")
+
     async def bench_collect(
         self, mission: str, service_name: str, timeout: float = 120.0
     ) -> dict[str, Any]:

--- a/orchestrator/agent_client.py
+++ b/orchestrator/agent_client.py
@@ -279,3 +279,13 @@ class AgentClient:
     async def delete_instance_schedule(self, service_name: str) -> None:
         """DELETE /agent/v1/instances/{serviceId}/schedule."""
         await self._delete(f"/instances/{service_name}/schedule")
+
+    async def bench_collect(
+        self, mission: str, service_name: str, timeout: float = 120.0
+    ) -> dict[str, Any]:
+        """POST /agent/v1/bench/collect — run afterburner record+push and return run_id."""
+        return await self._post(
+            "/bench/collect",
+            body={"mission": mission, "service_name": service_name},
+            timeout=timeout,
+        )

--- a/orchestrator/agent_client.py
+++ b/orchestrator/agent_client.py
@@ -282,7 +282,9 @@ class AgentClient:
 
     async def bench_monitor_start(self, service_name: str) -> dict[str, Any]:
         """POST /agent/v1/bench/monitor/start — start bench_monitor.py for an instance."""
-        return await self._post("/bench/monitor/start", body={"service_name": service_name})
+        return await self._post(
+            "/bench/monitor/start", body={"service_name": service_name}
+        )
 
     async def bench_monitor_stop(self) -> dict[str, Any]:
         """POST /agent/v1/bench/monitor/stop — stop the running bench monitor."""

--- a/orchestrator/api/app.py
+++ b/orchestrator/api/app.py
@@ -19,6 +19,7 @@ from fastapi.responses import JSONResponse
 from fastapi.staticfiles import StaticFiles
 
 from ..agent_client import AgentClient
+from ..bench_scheduler import BenchScheduler
 from ..config import OrchestratorConfig
 from ..database import Database
 from ..events import Event, EventBus
@@ -108,15 +109,20 @@ def create_app(config: OrchestratorConfig) -> FastAPI:
                 "Set 'api_key' in config before exposing this orchestrator on a network."
             )
         await db.connect()
+        scheduler = BenchScheduler(app, config)
+        app.state.bench_scheduler = scheduler
         poller = asyncio.create_task(_status_poller(app))
+        sched_task = asyncio.create_task(scheduler.run())
         try:
             yield
         finally:
             poller.cancel()
-            try:
-                await poller
-            except asyncio.CancelledError:
-                pass
+            sched_task.cancel()
+            for t in (poller, sched_task):
+                try:
+                    await t
+                except asyncio.CancelledError:
+                    pass
             await db.close()
 
     app = FastAPI(
@@ -132,7 +138,7 @@ def create_app(config: OrchestratorConfig) -> FastAPI:
     app.add_middleware(
         CORSMiddleware,
         allow_origins=["*"],
-        allow_methods=["GET", "POST"],
+        allow_methods=["GET", "POST", "DELETE"],
         allow_headers=["*"],
     )
 

--- a/orchestrator/api/routes/bench.py
+++ b/orchestrator/api/routes/bench.py
@@ -1,18 +1,24 @@
 """
-POST /api/v1/bench/runs  — ingest a bench run pushed by afterburner on the agent node
-GET  /api/v1/bench/runs  — list runs (public, no auth — read-only)
-GET  /api/v1/bench/runs/{run_id} — full run with timeseries (public)
+POST /api/v1/bench/runs         — ingest a bench run (agent-key auth)
+GET  /api/v1/bench/runs         — list runs (public)
+GET  /api/v1/bench/runs/{id}    — full run with timeseries (public)
 
-Agent auth for POST: X-Host-Id + X-Agent-Key headers (same as analytics).
+POST /api/v1/bench/queue        — add a mission to the bench queue (master key)
+GET  /api/v1/bench/queue        — list queue (master key)
+DELETE /api/v1/bench/queue/{id} — remove pending item (master key)
+POST /api/v1/bench/queue/{id}/run — trigger a queued item immediately (master key)
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Header, HTTPException, Request
+from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Request, UploadFile
 from pydantic import BaseModel
+
+from ..auth import require_api_key
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -112,3 +118,78 @@ async def get_bench_run(run_id: str, request: Request) -> dict[str, Any]:
     if not run:
         raise HTTPException(status_code=404, detail=f"Run not found: {run_id}")
     return run
+
+
+# ------------------------------------------------------------------
+# Bench queue (master API key required)
+# ------------------------------------------------------------------
+
+
+@router.post("/bench/queue", status_code=201, dependencies=[Depends(require_api_key)])
+async def enqueue_bench(
+    request: Request,
+    miz: UploadFile = File(...),
+    host_id: str = Form(""),
+    instance_id: str = Form(""),
+    duration_s: int = Form(1800),
+) -> dict[str, Any]:
+    config = request.app.state.config
+    db = request.app.state.db
+
+    effective_host = host_id or config.bench_host_id
+    effective_instance = instance_id or config.bench_instance_id
+    if not effective_host or not effective_instance:
+        raise HTTPException(
+            status_code=422,
+            detail="host_id and instance_id required (or set bench_host_id/bench_instance_id in config)",
+        )
+
+    if not miz.filename or not miz.filename.lower().endswith(".miz"):
+        raise HTTPException(status_code=422, detail="Uploaded file must be a .miz")
+
+    data = await miz.read()
+    item = await db.enqueue_bench(
+        miz_filename=miz.filename,
+        miz_data=data,
+        host_id=effective_host,
+        instance_id=effective_instance,
+        duration_s=duration_s,
+    )
+    logger.info(
+        "[bench/queue] queued %s for %s/%s duration=%ds → %s",
+        miz.filename,
+        effective_host,
+        effective_instance,
+        duration_s,
+        item["id"],
+    )
+    return item
+
+
+@router.get("/bench/queue", response_model=list[dict[str, Any]], dependencies=[Depends(require_api_key)])
+async def list_queue(request: Request) -> list[dict[str, Any]]:
+    return await request.app.state.db.list_queue()
+
+
+@router.delete("/bench/queue/{item_id}", status_code=204, dependencies=[Depends(require_api_key)])
+async def delete_queue_item(item_id: str, request: Request) -> None:
+    deleted = await request.app.state.db.delete_queue_item(item_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Item not found or not pending: {item_id}")
+
+
+@router.post("/bench/queue/{item_id}/run", dependencies=[Depends(require_api_key)])
+async def trigger_queue_item(item_id: str, request: Request) -> dict[str, str]:
+    db = request.app.state.db
+    item = await db.get_queue_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail=f"Queue item not found: {item_id}")
+    if item["status"] != "pending":
+        raise HTTPException(status_code=409, detail=f"Item is not pending (status={item['status']})")
+
+    scheduler = getattr(request.app.state, "bench_scheduler", None)
+    if scheduler is None:
+        raise HTTPException(status_code=503, detail="Bench scheduler not running")
+
+    asyncio.create_task(scheduler.run_item(item_id))
+    return {"status": "started", "id": item_id}

--- a/orchestrator/api/routes/bench.py
+++ b/orchestrator/api/routes/bench.py
@@ -15,7 +15,16 @@ import asyncio
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Depends, File, Form, Header, HTTPException, Request, UploadFile
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    Header,
+    HTTPException,
+    Request,
+    UploadFile,
+)
 from pydantic import BaseModel
 
 from ..auth import require_api_key
@@ -166,16 +175,24 @@ async def enqueue_bench(
     return item
 
 
-@router.get("/bench/queue", response_model=list[dict[str, Any]], dependencies=[Depends(require_api_key)])
+@router.get(
+    "/bench/queue",
+    response_model=list[dict[str, Any]],
+    dependencies=[Depends(require_api_key)],
+)
 async def list_queue(request: Request) -> list[dict[str, Any]]:
     return await request.app.state.db.list_queue()
 
 
-@router.delete("/bench/queue/{item_id}", status_code=204, dependencies=[Depends(require_api_key)])
+@router.delete(
+    "/bench/queue/{item_id}", status_code=204, dependencies=[Depends(require_api_key)]
+)
 async def delete_queue_item(item_id: str, request: Request) -> None:
     deleted = await request.app.state.db.delete_queue_item(item_id)
     if not deleted:
-        raise HTTPException(status_code=404, detail=f"Item not found or not pending: {item_id}")
+        raise HTTPException(
+            status_code=404, detail=f"Item not found or not pending: {item_id}"
+        )
 
 
 @router.post("/bench/queue/{item_id}/run", dependencies=[Depends(require_api_key)])
@@ -185,7 +202,9 @@ async def trigger_queue_item(item_id: str, request: Request) -> dict[str, str]:
     if not item:
         raise HTTPException(status_code=404, detail=f"Queue item not found: {item_id}")
     if item["status"] != "pending":
-        raise HTTPException(status_code=409, detail=f"Item is not pending (status={item['status']})")
+        raise HTTPException(
+            status_code=409, detail=f"Item is not pending (status={item['status']})"
+        )
 
     scheduler = getattr(request.app.state, "bench_scheduler", None)
     if scheduler is None:

--- a/orchestrator/bench_scheduler.py
+++ b/orchestrator/bench_scheduler.py
@@ -68,7 +68,10 @@ class BenchScheduler:
 
     async def run_item(self, item_id: str) -> None:
         if self._running:
-            logger.warning("[bench/sched] run_item called while already running — skipping %s", item_id)
+            logger.warning(
+                "[bench/sched] run_item called while already running — skipping %s",
+                item_id,
+            )
             return
 
         self._running = True
@@ -80,18 +83,24 @@ class BenchScheduler:
             self._running = False
             return
 
-        logger.info("[bench/sched] starting run for %s (%s)", item["miz_filename"], item_id)
+        logger.info(
+            "[bench/sched] starting run for %s (%s)", item["miz_filename"], item_id
+        )
         now = datetime.now(timezone.utc).isoformat()
         await db.update_queue_status(item_id, "running", started_at=now)
 
         try:
             run_id = await self._execute(item)
             completed = datetime.now(timezone.utc).isoformat()
-            await db.update_queue_status(item_id, "done", completed_at=completed, run_id=run_id)
+            await db.update_queue_status(
+                item_id, "done", completed_at=completed, run_id=run_id
+            )
             logger.info("[bench/sched] %s complete — run_id=%s", item_id, run_id)
         except Exception as exc:
             completed = datetime.now(timezone.utc).isoformat()
-            await db.update_queue_status(item_id, "failed", completed_at=completed, error=str(exc))
+            await db.update_queue_status(
+                item_id, "failed", completed_at=completed, error=str(exc)
+            )
             logger.error("[bench/sched] %s failed: %s", item_id, exc)
         finally:
             self._running = False
@@ -127,14 +136,22 @@ class BenchScheduler:
                 monitor_started = True
                 logger.info("[bench/sched] CPU monitor started for %s", service_name)
             except AgentError as exc:
-                logger.warning("[bench/sched] monitor start skipped (%s) — no CPU data", exc)
+                logger.warning(
+                    "[bench/sched] monitor start skipped (%s) — no CPU data", exc
+                )
 
             # 3. Load mission (stops DCS, loads, starts)
             logger.info("[bench/sched] loading mission on %s", service_name)
-            await client.trigger_action(service_name, "mission_load", {"mission": miz_filename})
+            await client.trigger_action(
+                service_name, "mission_load", {"mission": miz_filename}
+            )
 
             # 4. Wait for DCS to settle, then run for duration
-            logger.info("[bench/sched] waiting %ds settle + %ds bench", int(_SETTLE_DELAY), duration_s)
+            logger.info(
+                "[bench/sched] waiting %ds settle + %ds bench",
+                int(_SETTLE_DELAY),
+                duration_s,
+            )
             await asyncio.sleep(_SETTLE_DELAY)
             await asyncio.sleep(duration_s)
 
@@ -149,11 +166,15 @@ class BenchScheduler:
                     await client.bench_monitor_stop()
                     logger.info("[bench/sched] CPU monitor stopped")
                 except AgentError as exc:
-                    logger.warning("[bench/sched] monitor stop failed (non-fatal): %s", exc)
+                    logger.warning(
+                        "[bench/sched] monitor stop failed (non-fatal): %s", exc
+                    )
 
             # 7. Collect bench data via afterburner
             logger.info("[bench/sched] collecting bench data")
-            result = await client.bench_collect(miz_filename, service_name, timeout=120.0)
+            result = await client.bench_collect(
+                miz_filename, service_name, timeout=120.0
+            )
             run_id: str = result.get("run_id", "")
 
             # 8. Clean up the .miz

--- a/orchestrator/bench_scheduler.py
+++ b/orchestrator/bench_scheduler.py
@@ -1,0 +1,149 @@
+"""
+Bench scheduler — runs queued bench jobs during the configured UTC time window.
+
+Picks the oldest pending item from bench_queue, orchestrates the full run:
+  1. Upload .miz to agent active_missions_dir
+  2. mission_load on the target instance
+  3. Wait 60s for DCS to settle + duration_s for the bench run
+  4. Stop DCS
+  5. Call agent POST /bench/collect (runs afterburner record + push)
+  6. Delete the .miz from the agent
+  7. Mark the queue item done (or failed)
+
+The manual trigger endpoint (POST /bench/queue/{id}/run) calls run_item() directly,
+bypassing the window check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+
+from fastapi import FastAPI
+
+from .agent_client import AgentClient, AgentError
+from .config import OrchestratorConfig
+
+logger = logging.getLogger(__name__)
+
+_POLL_INTERVAL = 60.0
+_SETTLE_DELAY = 60.0  # seconds between mission_load and starting the bench timer
+
+
+def _in_window(start_utc: str, end_utc: str) -> bool:
+    now = datetime.now(timezone.utc)
+    now_hm = now.hour * 60 + now.minute
+    sh, sm = (int(x) for x in start_utc.split(":"))
+    eh, em = (int(x) for x in end_utc.split(":"))
+    return (sh * 60 + sm) <= now_hm < (eh * 60 + em)
+
+
+class BenchScheduler:
+    def __init__(self, app: FastAPI, config: OrchestratorConfig) -> None:
+        self._app = app
+        self._config = config
+        self._running: bool = False
+
+    async def run(self) -> None:
+        logger.info(
+            "[bench/sched] started — window %s–%s UTC",
+            self._config.bench_window_start_utc,
+            self._config.bench_window_end_utc,
+        )
+        while True:
+            await asyncio.sleep(_POLL_INTERVAL)
+            if not _in_window(
+                self._config.bench_window_start_utc,
+                self._config.bench_window_end_utc,
+            ):
+                continue
+            if self._running:
+                continue
+            db = self._app.state.db
+            item = await db.dequeue_next_pending()
+            if item is None:
+                continue
+            asyncio.create_task(self.run_item(item["id"]))
+
+    async def run_item(self, item_id: str) -> None:
+        if self._running:
+            logger.warning("[bench/sched] run_item called while already running — skipping %s", item_id)
+            return
+
+        self._running = True
+        db = self._app.state.db
+
+        item = await db.get_queue_item(item_id)
+        if item is None or item["status"] != "pending":
+            logger.warning("[bench/sched] item %s not found or not pending", item_id)
+            self._running = False
+            return
+
+        logger.info("[bench/sched] starting run for %s (%s)", item["miz_filename"], item_id)
+        now = datetime.now(timezone.utc).isoformat()
+        await db.update_queue_status(item_id, "running", started_at=now)
+
+        try:
+            run_id = await self._execute(item)
+            completed = datetime.now(timezone.utc).isoformat()
+            await db.update_queue_status(item_id, "done", completed_at=completed, run_id=run_id)
+            logger.info("[bench/sched] %s complete — run_id=%s", item_id, run_id)
+        except Exception as exc:
+            completed = datetime.now(timezone.utc).isoformat()
+            await db.update_queue_status(item_id, "failed", completed_at=completed, error=str(exc))
+            logger.error("[bench/sched] %s failed: %s", item_id, exc)
+        finally:
+            self._running = False
+
+    async def _execute(self, item: dict) -> str:
+        db = self._app.state.db
+        host = await db.get_host(item["host_id"])
+        if not host:
+            raise RuntimeError(f"Host not found: {item['host_id']}")
+
+        agent_base = host["agent_url"].rstrip("/") + "/agent/v1"
+        miz_filename = item["miz_filename"]
+        service_name = item["instance_id"]
+        duration_s = item["duration_s"]
+
+        # Re-read miz_data from DB (stripped from item dict by _queue_row_to_dict)
+        raw = await db._get_row(
+            "SELECT miz_data FROM bench_queue WHERE id = ?", (item["id"],)
+        )
+        if raw is None:
+            raise RuntimeError("Queue item disappeared")
+        miz_data: bytes = raw["miz_data"]
+
+        async with AgentClient(agent_base, host["agent_api_key"]) as client:
+            # 1. Upload .miz to active_missions_dir
+            logger.info("[bench/sched] uploading %s to agent", miz_filename)
+            await client.upload_active_mission(miz_filename, miz_data, timeout=120.0)
+
+            # 2. Load mission (stops DCS, loads, starts)
+            logger.info("[bench/sched] loading mission on %s", service_name)
+            await client.trigger_action(service_name, "mission_load", {"mission": miz_filename})
+
+            # 3. Wait for DCS to settle, then run for duration
+            logger.info("[bench/sched] waiting %ds settle + %ds bench", int(_SETTLE_DELAY), duration_s)
+            await asyncio.sleep(_SETTLE_DELAY)
+            await asyncio.sleep(duration_s)
+
+            # 4. Stop DCS
+            logger.info("[bench/sched] stopping %s", service_name)
+            await client.trigger_action(service_name, "stop")
+            await asyncio.sleep(10)  # brief pause before collect
+
+            # 5. Collect bench data via afterburner
+            logger.info("[bench/sched] collecting bench data")
+            result = await client.bench_collect(miz_filename, service_name, timeout=120.0)
+            run_id: str = result.get("run_id", "")
+
+            # 6. Clean up the .miz
+            logger.info("[bench/sched] deleting %s from agent", miz_filename)
+            try:
+                await client.delete_active_mission(miz_filename)
+            except AgentError as exc:
+                logger.warning("[bench/sched] delete failed (non-fatal): %s", exc)
+
+        return run_id

--- a/orchestrator/bench_scheduler.py
+++ b/orchestrator/bench_scheduler.py
@@ -120,26 +120,43 @@ class BenchScheduler:
             logger.info("[bench/sched] uploading %s to agent", miz_filename)
             await client.upload_active_mission(miz_filename, miz_data, timeout=120.0)
 
-            # 2. Load mission (stops DCS, loads, starts)
+            # 2. Start CPU monitor (non-fatal if not configured)
+            monitor_started = False
+            try:
+                await client.bench_monitor_start(service_name)
+                monitor_started = True
+                logger.info("[bench/sched] CPU monitor started for %s", service_name)
+            except AgentError as exc:
+                logger.warning("[bench/sched] monitor start skipped (%s) — no CPU data", exc)
+
+            # 3. Load mission (stops DCS, loads, starts)
             logger.info("[bench/sched] loading mission on %s", service_name)
             await client.trigger_action(service_name, "mission_load", {"mission": miz_filename})
 
-            # 3. Wait for DCS to settle, then run for duration
+            # 4. Wait for DCS to settle, then run for duration
             logger.info("[bench/sched] waiting %ds settle + %ds bench", int(_SETTLE_DELAY), duration_s)
             await asyncio.sleep(_SETTLE_DELAY)
             await asyncio.sleep(duration_s)
 
-            # 4. Stop DCS
+            # 5. Stop DCS
             logger.info("[bench/sched] stopping %s", service_name)
             await client.trigger_action(service_name, "stop")
-            await asyncio.sleep(10)  # brief pause before collect
+            await asyncio.sleep(10)  # brief pause so log flush completes
 
-            # 5. Collect bench data via afterburner
+            # 6. Stop CPU monitor
+            if monitor_started:
+                try:
+                    await client.bench_monitor_stop()
+                    logger.info("[bench/sched] CPU monitor stopped")
+                except AgentError as exc:
+                    logger.warning("[bench/sched] monitor stop failed (non-fatal): %s", exc)
+
+            # 7. Collect bench data via afterburner
             logger.info("[bench/sched] collecting bench data")
             result = await client.bench_collect(miz_filename, service_name, timeout=120.0)
             run_id: str = result.get("run_id", "")
 
-            # 6. Clean up the .miz
+            # 8. Clean up the .miz
             logger.info("[bench/sched] deleting %s from agent", miz_filename)
             try:
                 await client.delete_active_mission(miz_filename)

--- a/orchestrator/config.py
+++ b/orchestrator/config.py
@@ -37,6 +37,12 @@ class OrchestratorConfig:
     frp_port_range_start: int = 8800
     frp_port_range_end: int = 8899
     registration_enabled: bool = True
+    # Bench scheduler window in UTC (0200-0700 ET = 0600-1100 UTC during EDT)
+    bench_window_start_utc: str = "06:00"
+    bench_window_end_utc: str = "11:00"
+    # Default host and instance for automated bench runs
+    bench_host_id: str = ""
+    bench_instance_id: str = ""
 
 
 def load_config(path: Path | str = DEFAULT_CONFIG_PATH) -> OrchestratorConfig:
@@ -70,4 +76,8 @@ def load_config(path: Path | str = DEFAULT_CONFIG_PATH) -> OrchestratorConfig:
         frp_port_range_start=int(data.get("frp_port_range_start", 8800)),
         frp_port_range_end=int(data.get("frp_port_range_end", 8899)),
         registration_enabled=bool(data.get("registration_enabled", True)),
+        bench_window_start_utc=str(data.get("bench_window_start_utc", "06:00")),
+        bench_window_end_utc=str(data.get("bench_window_end_utc", "11:00")),
+        bench_host_id=str(data.get("bench_host_id", "")),
+        bench_instance_id=str(data.get("bench_instance_id", "")),
     )

--- a/orchestrator/database.py
+++ b/orchestrator/database.py
@@ -574,7 +574,10 @@ class Database:
         assert self._conn
         await self._conn.executemany(
             "INSERT INTO bench_timeseries (run_id, elapsed_s, drift_s, groups, units) VALUES (?,?,?,?,?)",
-            [(run_id, r["elapsed_s"], r["drift_s"], r["groups"], r["units"]) for r in rows],
+            [
+                (run_id, r["elapsed_s"], r["drift_s"], r["groups"], r["units"])
+                for r in rows
+            ],
         )
         await self._conn.commit()
 
@@ -586,7 +589,10 @@ class Database:
         assert self._conn
         await self._conn.executemany(
             "INSERT INTO bench_cpu (run_id, elapsed_s, cpu_pct, mem_mb, threads) VALUES (?,?,?,?,?)",
-            [(run_id, r["elapsed_s"], r["cpu_pct"], r["mem_mb"], r["threads"]) for r in rows],
+            [
+                (run_id, r["elapsed_s"], r["cpu_pct"], r["mem_mb"], r["threads"])
+                for r in rows
+            ],
         )
         await self._conn.commit()
 
@@ -602,7 +608,9 @@ class Database:
         )
         await self._conn.commit()
 
-    async def list_bench_runs(self, host_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    async def list_bench_runs(
+        self, host_id: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
         assert self._conn
         if host_id:
             sql = "SELECT * FROM bench_runs WHERE host_id = ? ORDER BY created_at DESC LIMIT ?"

--- a/orchestrator/database.py
+++ b/orchestrator/database.py
@@ -128,6 +128,23 @@ CREATE TABLE IF NOT EXISTS bench_findings (
 CREATE INDEX IF NOT EXISTS idx_bench_findings_run ON bench_findings(run_id);
 """
 
+_CREATE_BENCH_QUEUE = """
+CREATE TABLE IF NOT EXISTS bench_queue (
+    id           TEXT PRIMARY KEY,
+    miz_filename TEXT NOT NULL,
+    miz_data     BLOB NOT NULL,
+    host_id      TEXT NOT NULL,
+    instance_id  TEXT NOT NULL,
+    duration_s   INTEGER NOT NULL DEFAULT 1800,
+    status       TEXT NOT NULL DEFAULT 'pending',
+    created_at   TEXT NOT NULL,
+    started_at   TEXT,
+    completed_at TEXT,
+    run_id       TEXT,
+    error        TEXT
+);
+"""
+
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
@@ -143,6 +160,12 @@ def _host_row_to_dict(row: aiosqlite.Row) -> dict[str, Any]:
 def _inst_row_to_dict(row: aiosqlite.Row) -> dict[str, Any]:
     d = dict(row)
     d["tags"] = json.loads(d["tags"])
+    return d
+
+
+def _queue_row_to_dict(row: aiosqlite.Row) -> dict[str, Any]:
+    d = dict(row)
+    d.pop("miz_data", None)  # never expose raw bytes over API
     return d
 
 
@@ -165,6 +188,7 @@ class Database:
         await self._conn.executescript(_CREATE_BENCH_TIMESERIES)
         await self._conn.executescript(_CREATE_BENCH_CPU)
         await self._conn.executescript(_CREATE_BENCH_FINDINGS)
+        await self._conn.execute(_CREATE_BENCH_QUEUE)
         # Safe migration: add frp_port column if missing
         try:
             await self._conn.execute(_MIGRATE_HOSTS_FRP)
@@ -612,6 +636,88 @@ class Database:
         ) as cur:
             result["findings"] = [dict(r) for r in await cur.fetchall()]
         return result
+
+    # ------------------------------------------------------------------
+    # Bench queue
+    # ------------------------------------------------------------------
+
+    async def enqueue_bench(
+        self,
+        miz_filename: str,
+        miz_data: bytes,
+        host_id: str,
+        instance_id: str,
+        duration_s: int = 1800,
+    ) -> dict[str, Any]:
+        item_id = "bq_" + secrets.token_hex(6)
+        now = _now_iso()
+        assert self._conn
+        await self._conn.execute(
+            """
+            INSERT INTO bench_queue
+                (id, miz_filename, miz_data, host_id, instance_id, duration_s, status, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, 'pending', ?)
+            """,
+            (item_id, miz_filename, miz_data, host_id, instance_id, duration_s, now),
+        )
+        await self._conn.commit()
+        row = await self._get_row("SELECT * FROM bench_queue WHERE id = ?", (item_id,))
+        assert row is not None
+        return _queue_row_to_dict(row)
+
+    async def list_queue(self) -> list[dict[str, Any]]:
+        assert self._conn
+        async with self._conn.execute(
+            "SELECT * FROM bench_queue ORDER BY created_at ASC"
+        ) as cur:
+            rows = await cur.fetchall()
+        return [_queue_row_to_dict(r) for r in rows]
+
+    async def get_queue_item(self, item_id: str) -> dict[str, Any] | None:
+        row = await self._get_row("SELECT * FROM bench_queue WHERE id = ?", (item_id,))
+        return _queue_row_to_dict(row) if row else None
+
+    async def delete_queue_item(self, item_id: str) -> bool:
+        assert self._conn
+        cur = await self._conn.execute(
+            "DELETE FROM bench_queue WHERE id = ? AND status = 'pending'", (item_id,)
+        )
+        await self._conn.commit()
+        return (cur.rowcount or 0) > 0
+
+    async def dequeue_next_pending(self) -> dict[str, Any] | None:
+        """Return the oldest pending item without changing its status."""
+        row = await self._get_row(
+            "SELECT * FROM bench_queue WHERE status = 'pending' ORDER BY created_at ASC LIMIT 1",
+            (),
+        )
+        return _queue_row_to_dict(row) if row else None
+
+    async def update_queue_status(
+        self,
+        item_id: str,
+        status: str,
+        started_at: str | None = None,
+        completed_at: str | None = None,
+        run_id: str | None = None,
+        error: str | None = None,
+    ) -> None:
+        assert self._conn
+        fields: dict[str, Any] = {"status": status}
+        if started_at is not None:
+            fields["started_at"] = started_at
+        if completed_at is not None:
+            fields["completed_at"] = completed_at
+        if run_id is not None:
+            fields["run_id"] = run_id
+        if error is not None:
+            fields["error"] = error
+        set_clause = ", ".join(f"{k} = ?" for k in fields)
+        values = list(fields.values()) + [item_id]
+        await self._conn.execute(
+            f"UPDATE bench_queue SET {set_clause} WHERE id = ?", values
+        )
+        await self._conn.commit()
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/orchestrator/requirements.txt
+++ b/orchestrator/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.29
 httpx>=0.27
 aiosqlite>=0.20
 aiofiles>=23.0
+python-multipart>=0.0.9


### PR DESCRIPTION
## Summary

Adds the orchestrator side of the automated bench pipeline.

- `bench_queue` SQLite table — stores `.miz` blob, host/instance target, duration, status, timestamps, and resulting `run_id`
- DB methods: `enqueue_bench`, `list_queue`, `get_queue_item`, `dequeue_next_pending`, `update_queue_status`, `delete_queue_item`
- Queue endpoints (master API key required):
  - `POST /api/v1/bench/queue` — multipart upload of `.miz` + form params
  - `GET /api/v1/bench/queue` — list all items
  - `DELETE /api/v1/bench/queue/{id}` — remove pending item
  - `POST /api/v1/bench/queue/{id}/run` — trigger immediately (bypasses window check)
- `OrchestratorConfig` additions: `bench_window_start_utc` / `bench_window_end_utc` (default `06:00`–`11:00` UTC = 02:00–07:00 ET), `bench_host_id`, `bench_instance_id`
- `BenchScheduler`: polls every 60s, runs pending items within the window; full orchestration — upload → `mission_load` → wait → stop → `bench/collect` → delete `.miz`
- `AgentClient.bench_collect()` for the new agent endpoint
- CORS: add `DELETE` to allowed methods

## Test plan

- [ ] `POST /api/v1/bench/queue` with a `.miz` file — verify item in DB with status `pending`
- [ ] `GET /api/v1/bench/queue` — verify item appears
- [ ] `DELETE /api/v1/bench/queue/{id}` — verify item removed (only when pending)
- [ ] `POST /api/v1/bench/queue/{id}/run` — triggers immediate run (requires agent PR merged)
- [ ] Scheduler: set `bench_window_start_utc`/`end_utc` to current UTC time, verify item picks up within 60s
- [ ] Window boundary: item should not run outside configured window

## Notes

- Merge agent PR (`bench/agent-collect`) before doing an end-to-end test
- Scheduler `_execute` re-reads `miz_data` BLOB from DB directly (stripped from dict response to avoid exposing raw bytes over API)
- `bench_host_id` / `bench_instance_id` in config are the defaults; per-item overrides can be passed in the queue POST body
