### PR TITLE
bench: add POST /bench/collect to agent

### DIFF
--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -50,6 +50,7 @@ def create_app(config: AgentConfig) -> FastAPI:
     app.state.controller = DcsController(config)
     app.state.job_store = JobStore()
     app.state.nonce_store = NonceStore()
+    app.state.bench_monitor = {"proc": None, "service_name": None}
 
     # /health — no auth, no prefix
     app.include_router(health_routes.router)

--- a/agent/api/app.py
+++ b/agent/api/app.py
@@ -26,6 +26,7 @@ from .routes import health as health_routes
 from .routes import capabilities as capabilities_routes
 from .routes import instances as instances_routes
 from .routes import actions as actions_routes
+from .routes import bench as bench_routes
 from .routes import jobs as jobs_routes
 from .routes import schedule as schedule_routes
 
@@ -58,6 +59,7 @@ def create_app(config: AgentConfig) -> FastAPI:
     app.include_router(capabilities_routes.router, **_v1_kwargs)
     app.include_router(instances_routes.router, **_v1_kwargs)
     app.include_router(actions_routes.router, **_v1_kwargs)
+    app.include_router(bench_routes.router, **_v1_kwargs)
     app.include_router(jobs_routes.router, **_v1_kwargs)
     app.include_router(schedule_routes.router, **_v1_kwargs)
 

--- a/agent/api/routes/bench.py
+++ b/agent/api/routes/bench.py
@@ -33,8 +33,8 @@ class MonitorRequest(BaseModel):
 
 
 class CollectRequest(BaseModel):
-    mission: str      # bare filename, e.g. "mymission.miz"
-    service_name: str # instance service_name, e.g. "DCS-TexasBBQ"
+    mission: str  # bare filename, e.g. "mymission.miz"
+    service_name: str  # instance service_name, e.g. "DCS-TexasBBQ"
 
 
 def _find_instance(config, service_name: str) -> InstanceConfig | None:
@@ -67,11 +67,18 @@ async def start_monitor(payload: MonitorRequest, request: Request) -> dict[str, 
 
     inst = _find_instance(config, payload.service_name)
     if inst is None:
-        raise HTTPException(status_code=404, detail=f"Instance not found: {payload.service_name}")
+        raise HTTPException(
+            status_code=404, detail=f"Instance not found: {payload.service_name}"
+        )
     if not inst.bench_monitor_script:
-        raise HTTPException(status_code=422, detail="bench_monitor_script not configured for this instance")
+        raise HTTPException(
+            status_code=422,
+            detail="bench_monitor_script not configured for this instance",
+        )
     if not inst.bench_csv_path:
-        raise HTTPException(status_code=422, detail="bench_csv_path not configured for this instance")
+        raise HTTPException(
+            status_code=422, detail="bench_csv_path not configured for this instance"
+        )
 
     monitor_state = request.app.state.bench_monitor
     if monitor_state.get("proc") is not None:
@@ -80,8 +87,10 @@ async def start_monitor(payload: MonitorRequest, request: Request) -> dict[str, 
     cmd = [
         sys.executable,
         inst.bench_monitor_script,
-        "--server", inst.saved_games_key,
-        "--out", inst.bench_csv_path,
+        "--server",
+        inst.saved_games_key,
+        "--out",
+        inst.bench_csv_path,
     ]
     logger.info("[bench/monitor] starting: %s", " ".join(cmd))
     proc = await asyncio.create_subprocess_exec(
@@ -122,7 +131,9 @@ async def collect_bench(payload: CollectRequest, request: Request) -> dict[str, 
 
     inst = _find_instance(config, payload.service_name)
     if inst is None:
-        raise HTTPException(status_code=404, detail=f"Instance not found: {payload.service_name}")
+        raise HTTPException(
+            status_code=404, detail=f"Instance not found: {payload.service_name}"
+        )
 
     if not config.orchestrator_url:
         raise HTTPException(status_code=503, detail="orchestrator_url not configured")
@@ -131,7 +142,9 @@ async def collect_bench(payload: CollectRequest, request: Request) -> dict[str, 
 
     active_dir = config.active_missions_dir
     if not active_dir:
-        raise HTTPException(status_code=503, detail="active_missions_dir not configured")
+        raise HTTPException(
+            status_code=503, detail="active_missions_dir not configured"
+        )
 
     miz_path = str(Path(active_dir) / payload.mission)
     afterburner = config.afterburner_bin
@@ -150,9 +163,14 @@ async def collect_bench(payload: CollectRequest, request: Request) -> dict[str, 
 
     # Build push command
     push_cmd = [
-        afterburner, "bench", "push", config.orchestrator_url,
-        "--host-id", config.host_id,
-        "--key", config.api_key,
+        afterburner,
+        "bench",
+        "push",
+        config.orchestrator_url,
+        "--host-id",
+        config.host_id,
+        "--key",
+        config.api_key,
     ]
 
     logger.info("[bench/collect] pushing to %s", config.orchestrator_url)

--- a/agent/api/routes/bench.py
+++ b/agent/api/routes/bench.py
@@ -1,0 +1,106 @@
+"""
+POST /agent/v1/bench/collect — run afterburner bench record + push for a completed run.
+
+Called by the orchestrator scheduler after DCS has been stopped. Runs:
+  1. afterburner bench record <miz_path> --log <log_path> [--cpu <bench_csv_path>]
+  2. afterburner bench push <orchestrator_url> --host-id <host_id> --key <api_key>
+
+Returns {"run_id": "brun_xxx"} parsed from push stdout.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+from ...config import InstanceConfig
+
+logger = logging.getLogger(__name__)
+router = APIRouter()
+
+_RUN_ID_RE = re.compile(r"brun_[0-9a-f]+")
+
+
+class CollectRequest(BaseModel):
+    mission: str      # bare filename, e.g. "mymission.miz"
+    service_name: str # instance service_name, e.g. "DCS-TexasBBQ"
+
+
+def _find_instance(config, service_name: str) -> InstanceConfig | None:
+    for inst in config.instances:
+        if inst.service_name.lower() == service_name.lower():
+            return inst
+    return None
+
+
+async def _run(cmd: list[str], timeout: float = 90.0) -> str:
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        raise RuntimeError(f"Command timed out after {timeout}s: {' '.join(cmd)}")
+    output = stdout.decode(errors="replace")
+    if proc.returncode != 0:
+        raise RuntimeError(f"Command failed (exit {proc.returncode}): {output[:500]}")
+    return output
+
+
+@router.post("/bench/collect")
+async def collect_bench(payload: CollectRequest, request: Request) -> dict[str, str]:
+    config = request.app.state.config
+
+    inst = _find_instance(config, payload.service_name)
+    if inst is None:
+        raise HTTPException(status_code=404, detail=f"Instance not found: {payload.service_name}")
+
+    if not config.orchestrator_url:
+        raise HTTPException(status_code=503, detail="orchestrator_url not configured")
+    if not config.host_id:
+        raise HTTPException(status_code=503, detail="host_id not configured")
+
+    active_dir = config.active_missions_dir
+    if not active_dir:
+        raise HTTPException(status_code=503, detail="active_missions_dir not configured")
+
+    miz_path = str(Path(active_dir) / payload.mission)
+    afterburner = config.afterburner_bin
+
+    # Build record command
+    record_cmd = [afterburner, "bench", "record", miz_path, "--log", inst.log_path]
+    if inst.bench_csv_path:
+        record_cmd += ["--cpu", inst.bench_csv_path]
+
+    logger.info("[bench/collect] recording: %s", " ".join(record_cmd))
+    try:
+        record_out = await _run(record_cmd)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=f"bench record failed: {exc}")
+    logger.info("[bench/collect] record output: %s", record_out.strip())
+
+    # Build push command
+    push_cmd = [
+        afterburner, "bench", "push", config.orchestrator_url,
+        "--host-id", config.host_id,
+        "--key", config.api_key,
+    ]
+
+    logger.info("[bench/collect] pushing to %s", config.orchestrator_url)
+    try:
+        push_out = await _run(push_cmd)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=f"bench push failed: {exc}")
+    logger.info("[bench/collect] push output: %s", push_out.strip())
+
+    match = _RUN_ID_RE.search(push_out)
+    run_id = match.group(0) if match else ""
+    return {"run_id": run_id}

--- a/agent/api/routes/bench.py
+++ b/agent/api/routes/bench.py
@@ -1,11 +1,12 @@
 """
-POST /agent/v1/bench/collect — run afterburner bench record + push for a completed run.
+POST /agent/v1/bench/monitor/start — start bench_monitor.py for a given instance
+POST /agent/v1/bench/monitor/stop  — stop the running monitor
+POST /agent/v1/bench/collect       — run afterburner bench record + push after a run
 
-Called by the orchestrator scheduler after DCS has been stopped. Runs:
+Collect flow (called by orchestrator scheduler):
   1. afterburner bench record <miz_path> --log <log_path> [--cpu <bench_csv_path>]
   2. afterburner bench push <orchestrator_url> --host-id <host_id> --key <api_key>
-
-Returns {"run_id": "brun_xxx"} parsed from push stdout.
+  Returns {"run_id": "brun_xxx"} parsed from push stdout.
 """
 
 from __future__ import annotations
@@ -13,6 +14,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import re
+import sys
 from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Request
@@ -24,6 +26,10 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 _RUN_ID_RE = re.compile(r"brun_[0-9a-f]+")
+
+
+class MonitorRequest(BaseModel):
+    service_name: str  # e.g. "DCS-TexasBBQ"
 
 
 class CollectRequest(BaseModel):
@@ -53,6 +59,61 @@ async def _run(cmd: list[str], timeout: float = 90.0) -> str:
     if proc.returncode != 0:
         raise RuntimeError(f"Command failed (exit {proc.returncode}): {output[:500]}")
     return output
+
+
+@router.post("/bench/monitor/start")
+async def start_monitor(payload: MonitorRequest, request: Request) -> dict[str, str]:
+    config = request.app.state.config
+
+    inst = _find_instance(config, payload.service_name)
+    if inst is None:
+        raise HTTPException(status_code=404, detail=f"Instance not found: {payload.service_name}")
+    if not inst.bench_monitor_script:
+        raise HTTPException(status_code=422, detail="bench_monitor_script not configured for this instance")
+    if not inst.bench_csv_path:
+        raise HTTPException(status_code=422, detail="bench_csv_path not configured for this instance")
+
+    monitor_state = request.app.state.bench_monitor
+    if monitor_state.get("proc") is not None:
+        raise HTTPException(status_code=409, detail="Monitor already running")
+
+    cmd = [
+        sys.executable,
+        inst.bench_monitor_script,
+        "--server", inst.saved_games_key,
+        "--out", inst.bench_csv_path,
+    ]
+    logger.info("[bench/monitor] starting: %s", " ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.DEVNULL,
+        stderr=asyncio.subprocess.DEVNULL,
+    )
+    monitor_state["proc"] = proc
+    monitor_state["service_name"] = payload.service_name
+    return {"status": "started", "pid": str(proc.pid)}
+
+
+@router.post("/bench/monitor/stop")
+async def stop_monitor(request: Request) -> dict[str, str]:
+    monitor_state = request.app.state.bench_monitor
+    proc: asyncio.subprocess.Process | None = monitor_state.get("proc")
+    if proc is None:
+        return {"status": "not_running"}
+
+    try:
+        proc.terminate()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            proc.kill()
+    except ProcessLookupError:
+        pass
+
+    monitor_state["proc"] = None
+    monitor_state["service_name"] = None
+    logger.info("[bench/monitor] stopped")
+    return {"status": "stopped"}
 
 
 @router.post("/bench/collect")

--- a/agent/config.py
+++ b/agent/config.py
@@ -31,6 +31,7 @@ class InstanceConfig:
     auto_start: bool = True
     ports: dict = field(default_factory=dict)  # game/webgui/srs/tacview
     manager: str = "nssm"  # "nssm" or "task" (Windows Task Scheduler)
+    bench_csv_path: str = ""  # path to gm_bench.lua CSV output; empty = skip CPU data
 
 
 @dataclass
@@ -45,6 +46,7 @@ class AgentConfig:
     max_upload_bytes: int = 100 * 1024 * 1024  # max .miz upload size (default 100 MB)
     orchestrator_url: str = ""  # e.g. https://my-vps:8888 --� set by installer
     host_id: str = ""  # assigned by orchestrator at registration
+    afterburner_bin: str = "afterburner"  # path or name of the afterburner CLI
 
 
 def _parse_instances(raw: list[dict[str, Any]]) -> list[InstanceConfig]:
@@ -74,6 +76,7 @@ def _parse_instances(raw: list[dict[str, Any]]) -> list[InstanceConfig]:
                 auto_start=bool(item.get("auto_start", True)),
                 ports=dict(item.get("ports", {})),
                 manager=str(item.get("manager", "nssm")),
+                bench_csv_path=str(item.get("bench_csv_path", "")),
             )
         )
     return parsed
@@ -111,4 +114,5 @@ def load_config(path: Path | str = DEFAULT_CONFIG_PATH) -> AgentConfig:
         max_upload_bytes=int(data.get("max_upload_bytes", 100 * 1024 * 1024)),
         orchestrator_url=str(data.get("orchestrator_url", "")),
         host_id=str(data.get("host_id", "")),
+        afterburner_bin=str(data.get("afterburner_bin", "afterburner")),
     )

--- a/agent/config.py
+++ b/agent/config.py
@@ -31,8 +31,12 @@ class InstanceConfig:
     auto_start: bool = True
     ports: dict = field(default_factory=dict)  # game/webgui/srs/tacview
     manager: str = "nssm"  # "nssm" or "task" (Windows Task Scheduler)
-    bench_csv_path: str = ""  # output path for bench_monitor.py CSV; empty = skip CPU data
-    bench_monitor_script: str = ""  # path to bench_monitor.py; empty = no CPU monitoring
+    bench_csv_path: str = (
+        ""  # output path for bench_monitor.py CSV; empty = skip CPU data
+    )
+    bench_monitor_script: str = (
+        ""  # path to bench_monitor.py; empty = no CPU monitoring
+    )
 
 
 @dataclass

--- a/agent/config.py
+++ b/agent/config.py
@@ -31,7 +31,8 @@ class InstanceConfig:
     auto_start: bool = True
     ports: dict = field(default_factory=dict)  # game/webgui/srs/tacview
     manager: str = "nssm"  # "nssm" or "task" (Windows Task Scheduler)
-    bench_csv_path: str = ""  # path to gm_bench.lua CSV output; empty = skip CPU data
+    bench_csv_path: str = ""  # output path for bench_monitor.py CSV; empty = skip CPU data
+    bench_monitor_script: str = ""  # path to bench_monitor.py; empty = no CPU monitoring
 
 
 @dataclass
@@ -77,6 +78,7 @@ def _parse_instances(raw: list[dict[str, Any]]) -> list[InstanceConfig]:
                 ports=dict(item.get("ports", {})),
                 manager=str(item.get("manager", "nssm")),
                 bench_csv_path=str(item.get("bench_csv_path", "")),
+                bench_monitor_script=str(item.get("bench_monitor_script", "")),
             )
         )
     return parsed

--- a/orchestrator/database.py
+++ b/orchestrator/database.py
@@ -550,7 +550,10 @@ class Database:
         assert self._conn
         await self._conn.executemany(
             "INSERT INTO bench_timeseries (run_id, elapsed_s, drift_s, groups, units) VALUES (?,?,?,?,?)",
-            [(run_id, r["elapsed_s"], r["drift_s"], r["groups"], r["units"]) for r in rows],
+            [
+                (run_id, r["elapsed_s"], r["drift_s"], r["groups"], r["units"])
+                for r in rows
+            ],
         )
         await self._conn.commit()
 
@@ -562,7 +565,10 @@ class Database:
         assert self._conn
         await self._conn.executemany(
             "INSERT INTO bench_cpu (run_id, elapsed_s, cpu_pct, mem_mb, threads) VALUES (?,?,?,?,?)",
-            [(run_id, r["elapsed_s"], r["cpu_pct"], r["mem_mb"], r["threads"]) for r in rows],
+            [
+                (run_id, r["elapsed_s"], r["cpu_pct"], r["mem_mb"], r["threads"])
+                for r in rows
+            ],
         )
         await self._conn.commit()
 
@@ -578,7 +584,9 @@ class Database:
         )
         await self._conn.commit()
 
-    async def list_bench_runs(self, host_id: str | None = None, limit: int = 100) -> list[dict[str, Any]]:
+    async def list_bench_runs(
+        self, host_id: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
         assert self._conn
         if host_id:
             sql = "SELECT * FROM bench_runs WHERE host_id = ? ORDER BY created_at DESC LIMIT ?"


### PR DESCRIPTION
## Summary

Adds the agent side of the automated bench pipeline.

- `InstanceConfig.bench_csv_path` — optional path to the `gm_bench.lua` CSV output file; omit to skip CPU/memory data
- `AgentConfig.afterburner_bin` — path or name of the afterburner CLI (default `"afterburner"`)
- `POST /agent/v1/bench/collect` — called by the orchestrator scheduler after a bench run completes:
  1. Finds the instance by `service_name` to get `log_path` and `bench_csv_path`
  2. Runs `afterburner bench record <miz_path> --log <log_path> [--cpu <bench_csv>]`
  3. Runs `afterburner bench push <orchestrator_url> --host-id <host_id> --key <api_key>`
  4. Parses `brun_xxx` from push stdout and returns `{"run_id": "brun_xxx"}`

## Config example

Add to the relevant instance in `config.json`:
```json
{
  "afterburner_bin": "afterburner",
  "instances": [
    {
      "service_name": "DCS-TexasBBQ",
      "bench_csv_path": "C:\\Users\\DCSgoon\\AppData\\Local\\Temp\\gm_bench.csv"
    }
  ]
}
```

## Test plan

- [ ] `POST /agent/v1/bench/collect` with a completed mission name and service_name
- [ ] Verify afterburner record runs against the correct log path
- [ ] Verify bench push fires and `run_id` is returned
- [ ] Verify missing `orchestrator_url` / `host_id` returns 503
- [ ] Verify unknown `service_name` returns 404

## Notes

- `bench_csv_path` is optional — if empty, `--cpu` is not passed and CPU/memory data is skipped
- `api_key` used in `bench push --key` is the agent's own key (same value the orchestrator stores as `agent_api_key` in the hosts table)
- Can be tested independently of the orchestrator queue PR, but end-to-end requires both
