### PR TITLE
fix: task-stop no-op when DCS not running

### DIFF
--- a/agent/controller.py
+++ b/agent/controller.py
@@ -244,19 +244,18 @@ def _task_stop(saved_games_key: str, task_name: str = "") -> None:
 
     Also ends the Task Scheduler task so its status clears from 'Running', which
     allows schtasks /run to start a new instance immediately after.
+    No-op if the process is not running.
     """
     ps = (
         f"$p = Get-CimInstance Win32_Process -Filter \"name='DCS_server.exe'\" "
         f"| Where-Object {{ $_.CommandLine -like '*{saved_games_key}*' }}; "
-        f"if ($p) {{ Stop-Process -Id $p.ProcessId -Force; exit 0 }} else {{ exit 1 }}"
+        f"if ($p) {{ Stop-Process -Id $p.ProcessId -Force }}"
     )
-    result = subprocess.run(
+    subprocess.run(
         ["powershell", "-NoProfile", "-Command", ps],
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0:
-        raise RuntimeError(f"Could not find/stop DCS process for {saved_games_key!r}")
     # Clear the Task Scheduler "Running" state so the next /run isn't ignored
     if task_name:
         subprocess.run(


### PR DESCRIPTION
## Summary\n- `_task_stop()` raised `RuntimeError` when the DCS process wasn't found (exit 1 from the PowerShell lookup), causing `mission_load` → `restart()` to silently fail after the 202 was already returned\n- For bench runs on an idle TexasBBQ instance, this meant DCS never started but the scheduler waited the full 6 minutes before failing at collect\n- Fix: drop the exit-code check — if the process isn't there, the stop is already done\n\n## Test plan\n- [ ] Trigger a bench run on TexasBBQ while DCS is stopped — confirm DCS starts and the run completes