### PR TITLE
Store benchmark run diagnostics

### DIFF
--- a/agent/api/routes/bench.py
+++ b/agent/api/routes/bench.py
@@ -39,6 +39,8 @@ class InjectRequest(BaseModel):
 class CollectRequest(BaseModel):
     mission: str  # bare filename, e.g. "mymission.miz"
     service_name: str  # instance service_name, e.g. "DCS-TexasBBQ"
+    intended_duration_s: int | None = None
+    injection_status: str | None = None
 
 
 def _find_instance(config, service_name: str) -> InstanceConfig | None:
@@ -85,7 +87,17 @@ async def start_monitor(payload: MonitorRequest, request: Request) -> dict[str, 
         )
 
     monitor_state = request.app.state.bench_monitor
-    if monitor_state.get("proc") is not None:
+    existing: asyncio.subprocess.Process | None = monitor_state.get("proc")
+    if existing is not None and existing.returncode is not None:
+        logger.warning(
+            "[bench/monitor] clearing exited monitor process pid=%s rc=%s",
+            existing.pid,
+            existing.returncode,
+        )
+        monitor_state["proc"] = None
+        monitor_state["service_name"] = None
+        existing = None
+    if existing is not None:
         raise HTTPException(status_code=409, detail="Monitor already running")
 
     cmd = [
@@ -134,11 +146,15 @@ async def inject_bench(payload: InjectRequest, request: Request) -> dict[str, st
     config = request.app.state.config
     active_dir = config.active_missions_dir
     if not active_dir:
-        raise HTTPException(status_code=503, detail="active_missions_dir not configured")
+        raise HTTPException(
+            status_code=503, detail="active_missions_dir not configured"
+        )
 
     miz_path = Path(active_dir) / payload.mission
     if not miz_path.exists():
-        raise HTTPException(status_code=404, detail=f"Mission not found: {payload.mission}")
+        raise HTTPException(
+            status_code=404, detail=f"Mission not found: {payload.mission}"
+        )
 
     tmp_path = miz_path.parent / (miz_path.stem + ".injecting.miz")
     tmp_path.unlink(missing_ok=True)
@@ -159,7 +175,9 @@ async def inject_bench(payload: InjectRequest, request: Request) -> dict[str, st
         tmp_path.replace(miz_path)
     except OSError as exc:
         tmp_path.unlink(missing_ok=True)
-        raise HTTPException(status_code=500, detail=f"Failed to replace mission file: {exc}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to replace mission file: {exc}"
+        )
 
     logger.info("[bench/inject] done: %s", miz_path.name)
     return {"status": "injected"}
@@ -193,6 +211,10 @@ async def collect_bench(payload: CollectRequest, request: Request) -> dict[str, 
     record_cmd = [afterburner, "bench", "record", miz_path, "--log", inst.log_path]
     if inst.bench_csv_path and Path(inst.bench_csv_path).exists():
         record_cmd += ["--cpu", inst.bench_csv_path]
+    if payload.intended_duration_s is not None:
+        record_cmd += ["--intended-duration", str(payload.intended_duration_s)]
+    if payload.injection_status:
+        record_cmd += ["--injection-status", payload.injection_status]
 
     logger.info("[bench/collect] recording: %s", " ".join(record_cmd))
     try:

--- a/orchestrator/agent_client.py
+++ b/orchestrator/agent_client.py
@@ -299,11 +299,21 @@ class AgentClient:
         return await self._post("/bench/monitor/stop")
 
     async def bench_collect(
-        self, mission: str, service_name: str, timeout: float = 120.0
+        self,
+        mission: str,
+        service_name: str,
+        timeout: float = 120.0,
+        intended_duration_s: int | None = None,
+        injection_status: str | None = None,
     ) -> dict[str, Any]:
         """POST /agent/v1/bench/collect — run afterburner record+push and return run_id."""
+        body: dict[str, Any] = {"mission": mission, "service_name": service_name}
+        if intended_duration_s is not None:
+            body["intended_duration_s"] = intended_duration_s
+        if injection_status:
+            body["injection_status"] = injection_status
         return await self._post(
             "/bench/collect",
-            body={"mission": mission, "service_name": service_name},
+            body=body,
             timeout=timeout,
         )

--- a/orchestrator/api/routes/bench.py
+++ b/orchestrator/api/routes/bench.py
@@ -53,15 +53,30 @@ class BenchFinding(BaseModel):
     detail: str | None = None
 
 
+class BenchLogIssue(BaseModel):
+    issue_type: str
+    signature: str
+    count: int
+    first_line: str | None = None
+    last_line: str | None = None
+    detail: str | None = None
+
+
 class BenchRunPayload(BaseModel):
     mission: str
     started_at: str
     ended_at: str | None = None
     duration_s: int | None = None
+    intended_duration_s: int | None = None
+    bench_elapsed_s: int | None = None
+    run_quality: str = "unknown"
+    injection_status: str | None = None
+    hard_stop_error: str | None = None
     notes: str | None = None
     bench_timeseries: list[BenchTimeseriesRow] = []
     cpu_timeseries: list[BenchCpuRow] = []
     findings: list[BenchFinding] = []
+    log_issues: list[BenchLogIssue] = []
 
 
 @router.post("/bench/runs", status_code=201)
@@ -82,6 +97,11 @@ async def ingest_bench_run(
         started_at=payload.started_at,
         ended_at=payload.ended_at,
         duration_s=payload.duration_s,
+        intended_duration_s=payload.intended_duration_s,
+        bench_elapsed_s=payload.bench_elapsed_s,
+        run_quality=payload.run_quality,
+        injection_status=payload.injection_status,
+        hard_stop_error=payload.hard_stop_error,
         notes=payload.notes,
     )
 
@@ -97,15 +117,21 @@ async def ingest_bench_run(
         await db.insert_bench_findings(
             run_id, [r.model_dump() for r in payload.findings]
         )
+    if payload.log_issues:
+        await db.insert_bench_log_issues(
+            run_id, [r.model_dump() for r in payload.log_issues]
+        )
 
     logger.info(
-        "[bench] run %s recorded for host %s — mission=%s ts=%d cpu=%d findings=%d",
+        "[bench] run %s recorded for host %s — mission=%s ts=%d cpu=%d findings=%d issues=%d quality=%s",
         run_id,
         x_host_id,
         payload.mission,
         len(payload.bench_timeseries),
         len(payload.cpu_timeseries),
         len(payload.findings),
+        len(payload.log_issues),
+        payload.run_quality,
     )
     return {"id": run_id}
 

--- a/orchestrator/bench_scheduler.py
+++ b/orchestrator/bench_scheduler.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timezone
+from pathlib import Path
 
 from fastapi import FastAPI
 
@@ -33,6 +34,12 @@ logger = logging.getLogger(__name__)
 
 _POLL_INTERVAL = 60.0
 _SETTLE_DELAY = 60.0  # seconds between mission_load and starting the bench timer
+
+
+def _bench_miz_filename(item_id: str, original: str) -> str:
+    path = Path(original)
+    suffix = path.suffix if path.suffix else ".miz"
+    return f"{path.stem}__bench_{item_id}{suffix}"
 
 
 def _in_window(start_utc: str, end_utc: str) -> bool:
@@ -117,6 +124,7 @@ class BenchScheduler:
 
         agent_base = host["agent_url"].rstrip("/") + "/agent/v1"
         miz_filename = item["miz_filename"]
+        bench_miz_filename = _bench_miz_filename(item["id"], miz_filename)
         service_name = item["instance_id"]
         duration_s = item["duration_s"]
 
@@ -130,17 +138,26 @@ class BenchScheduler:
 
         async with AgentClient(agent_base, host["agent_api_key"]) as client:
             # 1. Upload .miz to active_missions_dir
-            logger.info("[bench/sched] uploading %s to agent", miz_filename)
-            await client.upload_active_mission(miz_filename, miz_data, timeout=120.0)
+            logger.info(
+                "[bench/sched] uploading %s to agent as %s",
+                miz_filename,
+                bench_miz_filename,
+            )
+            await client.upload_active_mission(
+                bench_miz_filename, miz_data, timeout=120.0
+            )
 
             # 2. Inject gm_bench.lua so DCS emits bench timing to dcs.log
-            logger.info("[bench/sched] injecting gm_bench into %s", miz_filename)
+            logger.info("[bench/sched] injecting gm_bench into %s", bench_miz_filename)
+            injection_status = "unknown"
             try:
-                inject_result = await client.bench_inject(miz_filename, timeout=60.0)
-                logger.info(
-                    "[bench/sched] inject: %s", inject_result.get("status", "ok")
+                inject_result = await client.bench_inject(
+                    bench_miz_filename, timeout=60.0
                 )
+                injection_status = str(inject_result.get("status", "ok"))
+                logger.info("[bench/sched] inject: %s", injection_status)
             except AgentError as exc:
+                injection_status = f"failed:{exc.status_code}"
                 logger.warning(
                     "[bench/sched] inject failed (%s) — no bench samples will be recorded",
                     exc,
@@ -149,7 +166,7 @@ class BenchScheduler:
             # 3. Load mission (stops DCS, loads, starts)
             logger.info("[bench/sched] loading mission on %s", service_name)
             await client.trigger_action(
-                service_name, "mission_load", {"mission": miz_filename}
+                service_name, "mission_load", {"mission": bench_miz_filename}
             )
 
             # 4. Wait for DCS to settle before starting monitor and bench timer
@@ -192,14 +209,18 @@ class BenchScheduler:
             # 9. Collect bench data via afterburner
             logger.info("[bench/sched] collecting bench data")
             result = await client.bench_collect(
-                miz_filename, service_name, timeout=120.0
+                bench_miz_filename,
+                service_name,
+                timeout=120.0,
+                intended_duration_s=duration_s,
+                injection_status=injection_status,
             )
             run_id: str = result.get("run_id", "")
 
             # 10. Clean up the .miz
-            logger.info("[bench/sched] deleting %s from agent", miz_filename)
+            logger.info("[bench/sched] deleting %s from agent", bench_miz_filename)
             try:
-                await client.delete_active_mission(miz_filename)
+                await client.delete_active_mission(bench_miz_filename)
             except AgentError as exc:
                 logger.warning("[bench/sched] delete failed (non-fatal): %s", exc)
 

--- a/orchestrator/database.py
+++ b/orchestrator/database.py
@@ -91,6 +91,11 @@ CREATE TABLE IF NOT EXISTS bench_runs (
     started_at  TEXT NOT NULL,
     ended_at    TEXT,
     duration_s  INTEGER,
+    intended_duration_s INTEGER,
+    bench_elapsed_s INTEGER,
+    run_quality TEXT NOT NULL DEFAULT 'unknown',
+    injection_status TEXT,
+    hard_stop_error TEXT,
     notes       TEXT,
     created_at  TEXT NOT NULL
 );
@@ -126,6 +131,19 @@ CREATE TABLE IF NOT EXISTS bench_findings (
     detail   TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_bench_findings_run ON bench_findings(run_id);
+"""
+
+_CREATE_BENCH_LOG_ISSUES = """
+CREATE TABLE IF NOT EXISTS bench_log_issues (
+    run_id     TEXT NOT NULL REFERENCES bench_runs(id),
+    issue_type TEXT NOT NULL,
+    signature  TEXT NOT NULL,
+    count      INTEGER NOT NULL,
+    first_line TEXT,
+    last_line  TEXT,
+    detail     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_bench_log_issues_run ON bench_log_issues(run_id);
 """
 
 _CREATE_BENCH_QUEUE = """
@@ -188,12 +206,24 @@ class Database:
         await self._conn.executescript(_CREATE_BENCH_TIMESERIES)
         await self._conn.executescript(_CREATE_BENCH_CPU)
         await self._conn.executescript(_CREATE_BENCH_FINDINGS)
+        await self._conn.executescript(_CREATE_BENCH_LOG_ISSUES)
         await self._conn.execute(_CREATE_BENCH_QUEUE)
         # Safe migration: add frp_port column if missing
         try:
             await self._conn.execute(_MIGRATE_HOSTS_FRP)
         except Exception:
             pass  # column already exists
+        for sql in (
+            "ALTER TABLE bench_runs ADD COLUMN intended_duration_s INTEGER",
+            "ALTER TABLE bench_runs ADD COLUMN bench_elapsed_s INTEGER",
+            "ALTER TABLE bench_runs ADD COLUMN run_quality TEXT NOT NULL DEFAULT 'unknown'",
+            "ALTER TABLE bench_runs ADD COLUMN injection_status TEXT",
+            "ALTER TABLE bench_runs ADD COLUMN hard_stop_error TEXT",
+        ):
+            try:
+                await self._conn.execute(sql)
+            except Exception:
+                pass  # column already exists
         await self._conn.commit()
 
     async def close(self) -> None:
@@ -551,6 +581,11 @@ class Database:
         started_at: str,
         ended_at: str | None = None,
         duration_s: int | None = None,
+        intended_duration_s: int | None = None,
+        bench_elapsed_s: int | None = None,
+        run_quality: str = "unknown",
+        injection_status: str | None = None,
+        hard_stop_error: str | None = None,
         notes: str | None = None,
     ) -> str:
         run_id = "brun_" + secrets.token_hex(6)
@@ -558,10 +593,28 @@ class Database:
         assert self._conn
         await self._conn.execute(
             """
-            INSERT INTO bench_runs (id, host_id, mission, started_at, ended_at, duration_s, notes, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO bench_runs (
+                id, host_id, mission, started_at, ended_at, duration_s,
+                intended_duration_s, bench_elapsed_s, run_quality,
+                injection_status, hard_stop_error, notes, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (run_id, host_id, mission, started_at, ended_at, duration_s, notes, now),
+            (
+                run_id,
+                host_id,
+                mission,
+                started_at,
+                ended_at,
+                duration_s,
+                intended_duration_s,
+                bench_elapsed_s,
+                run_quality,
+                injection_status,
+                hard_stop_error,
+                notes,
+                now,
+            ),
         )
         await self._conn.commit()
         return run_id
@@ -608,6 +661,33 @@ class Database:
         )
         await self._conn.commit()
 
+    async def insert_bench_log_issues(
+        self,
+        run_id: str,
+        rows: list[dict[str, Any]],
+    ) -> None:
+        assert self._conn
+        await self._conn.executemany(
+            """
+            INSERT INTO bench_log_issues
+                (run_id, issue_type, signature, count, first_line, last_line, detail)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            [
+                (
+                    run_id,
+                    r["issue_type"],
+                    r["signature"],
+                    r["count"],
+                    r.get("first_line"),
+                    r.get("last_line"),
+                    r.get("detail"),
+                )
+                for r in rows
+            ],
+        )
+        await self._conn.commit()
+
     async def list_bench_runs(
         self, host_id: str | None = None, limit: int = 100
     ) -> list[dict[str, Any]]:
@@ -643,6 +723,16 @@ class Database:
             (run_id,),
         ) as cur:
             result["findings"] = [dict(r) for r in await cur.fetchall()]
+        async with self._conn.execute(
+            """
+            SELECT issue_type, signature, count, first_line, last_line, detail
+            FROM bench_log_issues
+            WHERE run_id = ?
+            ORDER BY issue_type, count DESC
+            """,
+            (run_id,),
+        ) as cur:
+            result["log_issues"] = [dict(r) for r in await cur.fetchall()]
         return result
 
     # ------------------------------------------------------------------


### PR DESCRIPTION

  ## Summary
  - add benchmark run fields for intended duration, bench elapsed time, run quality, injection status, and hard-stop errors
  - store parsed benchmark log issues in the orchestrator database
  - pass injection status and intended duration through scheduler, agent client, and agent collection
  - return stored log issues from benchmark run API responses

  ## Testing
  - ruff check on touched files
  - ruff format --check on touched files
  - python -m py_compile on touched files

  ## Notes
  Full Bullseye test run was blocked locally by missing aiohttp / local async test harness behavior.

