### PR TITLE
feat: performance scoring + player join/leave notifications

### DIFF
--- a/discord-bot/cogs/events.py
+++ b/discord-bot/cogs/events.py
@@ -253,10 +253,8 @@ class EventsCog(commands.Cog):
         await channel.send(embed=embed)
 
     async def _on_player_joined(self, channel: discord.TextChannel, data: dict) -> None:
-        payload = data.get("data", {})
-        player_name = payload.get("playerName", "Unknown")
+        player_name = data.get("playerName", "Unknown")
         instance_id = data.get("instanceId", "Unknown")
-        # In this event, we don't have the friendly name, so use ID
         instance_name = instance_id
 
         now = time.monotonic()
@@ -276,8 +274,7 @@ class EventsCog(commands.Cog):
         # if count > threshold, suppress (already notified)
 
     async def _on_player_left(self, channel: discord.TextChannel, data: dict) -> None:
-        payload = data.get("data", {})
-        player_name = payload.get("playerName", "Unknown")
+        player_name = data.get("playerName", "Unknown")
         instance_id = data.get("instanceId", "Unknown")
         instance_name = instance_id
 

--- a/discord-bot/cogs/events.py
+++ b/discord-bot/cogs/events.py
@@ -29,9 +29,12 @@ if TYPE_CHECKING:
 
 log = logging.getLogger(__name__)
 
-_SUBSCRIBE_TYPES = "instance.status_changed,job.failed"
+_SUBSCRIBE_TYPES = "instance.status_changed,job.failed,player.joined,player.left"
 _MIN_BACKOFF = 1.0
 _MAX_BACKOFF = 60.0
+
+_JOIN_SPAM_WINDOW = 60.0  # seconds
+_JOIN_SPAM_THRESHOLD = 5  # joins per window before consolidating
 
 _CRASH_LOOP_WINDOW = 600.0  # seconds — sliding window for crash detection
 _CRASH_LOOP_THRESHOLD = 3  # crashes within the window triggers an alert
@@ -57,6 +60,8 @@ class EventsCog(commands.Cog):
         # crash loop detection: instance_id → list of crash timestamps (monotonic)
         self._crash_times: dict[str, list[float]] = {}
         self._crash_loop_alerted: set[str] = set()
+        # player join spam tracking: instance_id → list of join timestamps (monotonic)
+        self._recent_joins: dict[str, list[float]] = {}
 
     async def cog_load(self) -> None:
         self._task = asyncio.create_task(self._sse_loop())
@@ -147,6 +152,10 @@ class EventsCog(commands.Cog):
                 await self._on_status_changed(channel, data)
             elif event_type == "job.failed":
                 await self._on_job_failed(channel, data)
+            elif event_type == "player.joined":
+                await self._on_player_joined(channel, data)
+            elif event_type == "player.left":
+                await self._on_player_left(channel, data)
         except Exception as exc:
             log.warning("Failed to post event notification: %s", exc)
 
@@ -242,3 +251,34 @@ class EventsCog(commands.Cog):
         if error_msg:
             embed.add_field(name="Error", value=error_msg, inline=False)
         await channel.send(embed=embed)
+
+    async def _on_player_joined(self, channel: discord.TextChannel, data: dict) -> None:
+        payload = data.get("data", {})
+        player_name = payload.get("playerName", "Unknown")
+        instance_id = data.get("instanceId", "Unknown")
+        # In this event, we don't have the friendly name, so use ID
+        instance_name = instance_id
+
+        now = time.monotonic()
+        times = self._recent_joins.get(instance_id, [])
+        # prune timestamps outside the sliding window
+        times = [t for t in times if now - t <= _JOIN_SPAM_WINDOW]
+        times.append(now)
+        self._recent_joins[instance_id] = times
+
+        count = len(times)
+        if count < _JOIN_SPAM_THRESHOLD:
+            await channel.send(f"🟢 **{player_name}** joined **{instance_name}**")
+        elif count == _JOIN_SPAM_THRESHOLD:
+            await channel.send(
+                f"🟢 **{count}** players joined **{instance_name}** in the last {int(_JOIN_SPAM_WINDOW)}s"
+            )
+        # if count > threshold, suppress (already notified)
+
+    async def _on_player_left(self, channel: discord.TextChannel, data: dict) -> None:
+        payload = data.get("data", {})
+        player_name = payload.get("playerName", "Unknown")
+        instance_id = data.get("instanceId", "Unknown")
+        instance_name = instance_id
+
+        await channel.send(f"🔴 **{player_name}** left **{instance_name}**")

--- a/orchestrator/api/routes/analytics.py
+++ b/orchestrator/api/routes/analytics.py
@@ -60,7 +60,9 @@ async def ingest_events(
 
         # Publish player join/leave to the event bus for real-time notifications
         if ev.event_type in ("player_join", "player_leave"):
-            event_type = "player.joined" if ev.event_type == "player_join" else "player.left"
+            event_type = (
+                "player.joined" if ev.event_type == "player_join" else "player.left"
+            )
             request.app.state.event_bus.publish(
                 Event(
                     type=event_type,

--- a/orchestrator/api/routes/analytics.py
+++ b/orchestrator/api/routes/analytics.py
@@ -14,6 +14,8 @@ from typing import Any
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from pydantic import BaseModel
 
+from orchestrator.events import Event
+
 from ..auth import require_api_key
 
 logger = logging.getLogger(__name__)
@@ -55,6 +57,22 @@ async def ingest_events(
             map=ev.map,
             timestamp=ev.timestamp,
         )
+
+        # Publish player join/leave to the event bus for real-time notifications
+        if ev.event_type in ("player_join", "player_leave"):
+            event_type = "player.joined" if ev.event_type == "player_join" else "player.left"
+            request.app.state.event_bus.publish(
+                Event(
+                    type=event_type,
+                    data={
+                        "playerName": ev.player_name,
+                        "instanceId": ev.instance_id,
+                        "missionName": ev.mission_name,
+                    },
+                    instance_id=ev.instance_id,
+                    host_id=x_host_id,
+                )
+            )
 
     if batch.events:
         logger.debug("[analytics] %s wrote %d event(s)", x_host_id, len(batch.events))

--- a/orchestrator/database.py
+++ b/orchestrator/database.py
@@ -327,6 +327,42 @@ def _validity_status(run: dict[str, Any], bench_count: int, cpu_count: int) -> s
     return "unknown"
 
 
+def _compute_performance_score(
+    summary: dict[str, Any], critical_findings: int, warning_findings: int
+) -> float | None:
+    if summary.get("validity_status") != "valid":
+        return None
+
+    score = 100.0
+
+    p95_drift_s = summary.get("p95_drift_s")
+    if p95_drift_s is not None:
+        if p95_drift_s <= 0.5:
+            pass
+        elif p95_drift_s <= 2.0:
+            score -= 10.0
+        elif p95_drift_s <= 5.0:
+            score -= 20.0
+        else:
+            score -= 35.0
+
+    p95_cpu_pct = summary.get("p95_cpu_pct")
+    if p95_cpu_pct is not None:
+        if p95_cpu_pct < 40.0:
+            pass
+        elif p95_cpu_pct <= 60.0:
+            score -= 10.0
+        elif p95_cpu_pct <= 75.0:
+            score -= 20.0
+        else:
+            score -= 30.0
+
+    score -= min((critical_findings * 15.0) + (warning_findings * 5.0), 30.0)
+    score -= min((summary.get("log_issue_count") or 0) * 2.0, 15.0)
+
+    return max(0.0, min(score, 100.0))
+
+
 class Database:
     def __init__(self, db_path: str) -> None:
         self._path = db_path
@@ -902,6 +938,26 @@ class Database:
             "performance_score": performance_score,
             "computed_at": _now_iso(),
         }
+
+        if performance_score is None:
+            async with self._conn.execute(
+                """
+                SELECT severity, COUNT(*) AS count
+                FROM bench_findings
+                WHERE run_id = ?
+                GROUP BY severity
+                """,
+                (run_id,),
+            ) as cur:
+                finding_counts = {
+                    str(r["severity"]).lower(): int(r["count"])
+                    for r in await cur.fetchall()
+                }
+            summary["performance_score"] = _compute_performance_score(
+                summary,
+                finding_counts.get("critical", 0),
+                finding_counts.get("warning", 0),
+            )
 
         await self._conn.execute(
             """

--- a/orchestrator/tests/test_analytics_events.py
+++ b/orchestrator/tests/test_analytics_events.py
@@ -1,26 +1,26 @@
 from fastapi.testclient import TestClient
 
-def test_ingest_player_events_publishes_to_bus(client: TestClient, host_id: str, instance_id: str):
+
+def test_ingest_player_events_publishes_to_bus(
+    client: TestClient, host_id: str, instance_id: str
+):
     payload = {
         "events": [
             {
                 "instance_id": instance_id,
                 "event_type": "player_join",
                 "player_name": "Test Player",
-                "timestamp": "2026-05-01T12:00:00Z"
+                "timestamp": "2026-05-01T12:00:00Z",
             },
             {
                 "instance_id": instance_id,
                 "event_type": "player_leave",
                 "player_name": "Test Player",
-                "timestamp": "2026-05-01T12:05:00Z"
-            }
+                "timestamp": "2026-05-01T12:05:00Z",
+            },
         ]
     }
-    headers = {
-        "X-Host-Id": host_id,
-        "X-Agent-Key": "agent-key"
-    }
+    headers = {"X-Host-Id": host_id, "X-Agent-Key": "agent-key"}
     resp = client.post("/api/v1/analytics/events", headers=headers, json=payload)
     assert resp.status_code == 204
 
@@ -28,7 +28,7 @@ def test_ingest_player_events_publishes_to_bus(client: TestClient, host_id: str,
     # The event bus is in app.state.event_bus
     event_bus = client.app.state.event_bus
     recent = event_bus.recent(limit=10)
-    
+
     types = [e.type for e in recent]
     assert "player.joined" in types
     assert "player.left" in types

--- a/orchestrator/tests/test_analytics_events.py
+++ b/orchestrator/tests/test_analytics_events.py
@@ -1,5 +1,3 @@
-
-import pytest
 from fastapi.testclient import TestClient
 
 def test_ingest_player_events_publishes_to_bus(client: TestClient, host_id: str, instance_id: str):

--- a/orchestrator/tests/test_analytics_events.py
+++ b/orchestrator/tests/test_analytics_events.py
@@ -1,0 +1,41 @@
+
+import pytest
+from fastapi.testclient import TestClient
+
+def test_ingest_player_events_publishes_to_bus(client: TestClient, host_id: str, instance_id: str):
+    payload = {
+        "events": [
+            {
+                "instance_id": instance_id,
+                "event_type": "player_join",
+                "player_name": "Test Player",
+                "timestamp": "2026-05-01T12:00:00Z"
+            },
+            {
+                "instance_id": instance_id,
+                "event_type": "player_leave",
+                "player_name": "Test Player",
+                "timestamp": "2026-05-01T12:05:00Z"
+            }
+        ]
+    }
+    headers = {
+        "X-Host-Id": host_id,
+        "X-Agent-Key": "agent-key"
+    }
+    resp = client.post("/api/v1/analytics/events", headers=headers, json=payload)
+    assert resp.status_code == 204
+
+    # Verify event bus history
+    # The event bus is in app.state.event_bus
+    event_bus = client.app.state.event_bus
+    recent = event_bus.recent(limit=10)
+    
+    types = [e.type for e in recent]
+    assert "player.joined" in types
+    assert "player.left" in types
+
+    join_event = next(e for e in recent if e.type == "player.joined")
+    assert join_event.data["playerName"] == "Test Player"
+    assert join_event.instance_id == instance_id
+    assert join_event.host_id == host_id

--- a/orchestrator/tests/test_bench.py
+++ b/orchestrator/tests/test_bench.py
@@ -1,6 +1,36 @@
 from fastapi.testclient import TestClient
 
+from orchestrator.database import _compute_performance_score
+
 from .conftest import HEADERS
+
+
+def test_compute_performance_score_applies_deductions_and_caps() -> None:
+    summary = {
+        "validity_status": "valid",
+        "p95_drift_s": 3.0,
+        "p95_cpu_pct": 76.0,
+        "log_issue_count": 20,
+    }
+
+    assert (
+        _compute_performance_score(summary, critical_findings=2, warning_findings=10)
+        == 5.0
+    )
+
+
+def test_compute_performance_score_skips_invalid_runs() -> None:
+    summary = {
+        "validity_status": "partial",
+        "p95_drift_s": 0.1,
+        "p95_cpu_pct": 10.0,
+        "log_issue_count": 0,
+    }
+
+    assert (
+        _compute_performance_score(summary, critical_findings=0, warning_findings=0)
+        is None
+    )
 
 
 def test_ingest_bench_run_populates_summary(client: TestClient, host_id: str) -> None:
@@ -52,10 +82,12 @@ def test_ingest_bench_run_populates_summary(client: TestClient, host_id: str) ->
     assert runs[0]["summary"]["cpu_sample_count"] == 2
     assert runs[0]["summary"]["findings_count"] == 1
     assert runs[0]["summary"]["log_issue_count"] == 1
+    assert runs[0]["summary"]["performance_score"] == 88.0
 
     detail_resp = client.get(f"/api/v1/bench/runs/{run_id}", headers=HEADERS)
     assert detail_resp.status_code == 200
     run = detail_resp.json()
     assert run["summary"]["validity_status"] == "valid"
+    assert run["summary"]["performance_score"] == 88.0
     assert len(run["bench_timeseries"]) == 2
     assert len(run["cpu_timeseries"]) == 2


### PR DESCRIPTION
- Add _compute_performance_score() to database.py; auto-computed in refresh_bench_run_summary() unless caller supplies a value
- Publish player.joined/player.left events to SSE bus from analytics route
- Bot handles player events with 5-join/60s spam consolidation
- Tests for scoring logic and analytics event publishing